### PR TITLE
Use composer update when installing site

### DIFF
--- a/source/documentation.md
+++ b/source/documentation.md
@@ -19,7 +19,7 @@ First, clone the repository for the website:
 Second, get Composer and install the project dependencies (including Sculpin):
 
     wget http://getcomposer.org/composer.phar
-    php composer.phar install
+    php composer.phar update
 
 Third, generate the site:
 


### PR DESCRIPTION
composer.lock is no longer being versioned, so deps must be installed using `update` instead of `install`
