### PR TITLE
Added context to code example of composer.json

### DIFF
--- a/source/download.md
+++ b/source/download.md
@@ -51,11 +51,13 @@ Sculpin can be added to any existing Composer managed project by simply
 requiring Sculpin (and a couple of other dev dependencies) in `composer.json`.
 
     {
-        "sculpin/sculpin": "2.*@dev",
-
-        "dflydev/embedded-composer-console": "@dev",
-        "dflydev/embedded-composer-core": "@dev",
-        "composer/composer": "@dev"
+        "require": {
+            "sculpin/sculpin": "2.*@dev",
+    
+            "dflydev/embedded-composer-console": "@dev",
+            "dflydev/embedded-composer-core": "@dev",
+            "composer/composer": "@dev"
+        }
     }
 
 Sculpin currently relies on Embedded Composer and Composer, neither of which


### PR DESCRIPTION
If someone wasn't super familiar with composer they may think that your code sample was the contents of composer.json and not just rows to add to require.  This adds context so it's clearer where they would go in composer.json.
