### PR TITLE
Correct link to sculpin website on GitHub

### DIFF
--- a/source/blog.md
+++ b/source/blog.md
@@ -6,7 +6,7 @@ title: Blog
 
 # Blog
 
-The Sculpin website is now [self hosted](https://github.com/sculpin/getsculpin.com)!
+The Sculpin website is now [self hosted](https://github.com/sculpin/sculpin.io)!
 However, there is still a long ways to go before a fully working Version 2
 can be released. Included in that is better baked in blogging functionality.
 Hence the static page for now. ;) Check back soon!


### PR DESCRIPTION
The link for the sculpin website repo was incorrect so I changed it to the correct one.
