### PR TITLE
Typo in the slug, mismatching the URL

### DIFF
--- a/source/documentation/extending-sculpin/configuration.md
+++ b/source/documentation/extending-sculpin/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-slug: extending-sculping/configuration
+slug: extending-sculpin/configuration
 
 ---
 


### PR DESCRIPTION
Typo in the slug mismatching the URL causing the page not marked active on the menu on the left.
