### PR TITLE
Clarified steps for new users.

### DIFF
--- a/source/getstarted.md
+++ b/source/getstarted.md
@@ -108,9 +108,7 @@ Using your favorite text editor open up the file and let's write a message in th
 
     *Markdown is cool.*
 
-    **So is twig, because it knows this page's name is: { { page.title }}**
-
-Note: You will need to remove the space between the two { on the last line so that it renders `page.title` as a twig variable.
+    {% verbatim %}**So is twig, because it knows this page's name is: {{ page.title }}**{% endverbatim %}
 
 Save the file.
 


### PR DESCRIPTION
- Expanded the four steps to the discrete steps outlined in the
  document.
- Clarified the steps to use the implied verbs (not "get" but "download
  and install").
- Moved the downloading of the blog skeleton from the "run" section to
  the "download and install" section as it's part of the setup.
- Fixed a couple of spelling mistakes ("let's" is "let us", "lets" is
  "permits")
- Added a space between to the sample twig output to escape the
  variable (and added a note explaining people should take this out).
  Otherwise the variable renders and you get the page title.
- Separated the publish step into two: generate production-ready site;
  and upload to the server.
- Updated the what's next section to point to the documentation, or look
  at examples of what you can build with Sculpin.
