### PR TITLE
Blog skeleton is not a subproject as implied.

### DIFF
--- a/source/getstarted.md
+++ b/source/getstarted.md
@@ -60,10 +60,6 @@ Now we must tell Sculpin to install any relevant dependencies for your project. 
     cd ~/myblog
     sculpin install
 
-If you get permisson errors, you may need to run this command as your root user:
-
-    sudo sculpin install
-
 You are now ready to start the server, and add content to your new Sculpin site.
 
 ---


### PR DESCRIPTION
In issue #33 I shuffled the content around a bit. Taking a look at it again, I think I was confused. I've updated the page so that the blog skeleton doesn't seem like a sub-project.
- Moved directory information to the blog skeleton section.
- Removed reference to going back to your Sculpin project before
  downloading the blog skeleton. That was bad information.
- Fixed white space issues.
