### PR TITLE
Added documentation on source file formatting.

### DIFF
--- a/source/documentation/basic-project.md
+++ b/source/documentation/basic-project.md
@@ -1,5 +1,5 @@
 ---
-title: Basic Sculpin Project
+title: Basic Project
 slug: basic-project
 
 ---
@@ -19,57 +19,4 @@ Sculpin assumes a basic filesystem structure for any Sculpin project.
     |  `-- _views/                     # Templates
     `-- sculpin.json                   # Dependencies
 
----
-
-## Hello World Project
-
-To get started, try creating a simple "Hello World" project for Sculpin. By
-following these rules you can get started with a completely bare Sulpin site in
-no time!
-
-### Hello World Directory Structure
-
-The directory structure of a Sculpin project is pretty simple. By default,
-Sculpin assumes that there will be a `source/` directory in your project root.
-Sculpin will read all of the files in your source directory.
-
-Create a file called `index.md` in your source directory. Sculpin will
-automatically translate this file to `index.html` when it generates your site.
-
-Your project should now look like this:
-
-    |-- source/
-       `-- index.md
-
-### Smallest Source File
-
-The contents of `index.md` should look like this. We will talk about this in
-more detail later in the [Sources]({{site.url}}/documentation/sources/) section.
-For now, just type this in exactly.
-
-    ---
-    ---
-
-    # Hello World
-
-
-### Run and View
-
-Your project now has everything Sculpin needs to know in order to generate your
-Hello World project. For now, we are going to use the `--watch` and `--server`
-flags. This tells Sculpind to *watch* the source directory for changes (so it
-can regenerate the site as you edit your files) and to *serve* the site using an
-embedded web server.
-
-    sculpin generate --watch --server
-
-Visit [localhost:8000](http://localhost:8000) to see your new static site!
-
-
-### Output
-
-The static files are placed in `output_dev`. Explore the `output_dev` directory
-to see what is happening behind the scenes:
-
-    |-- output_dev/
-    |  `-- index.html
+To generate a Sculpin site, you must have at least the directory `source` (although it can be an empty directory).

--- a/source/documentation/content-types/custom-types.md
+++ b/source/documentation/content-types/custom-types.md
@@ -56,6 +56,23 @@ the following keys are available:
  * **enabled**:
    Whether or not the content type should be enabled. Defaults to `true`.
 
+### Frontmatter YAML Structures
+
+The YAML frontmatter is parsed and injected into every page rendering
+and is accessible as `page.KEY`.
+
+Sculpin will read deep structures in YAML frontmatter. In your output file, use the dot notation to indicate that you want to descend into a structure. For example:
+
+    ---
+    layout: default
+    something:
+        here:
+            very: deep
+            also: deep
+    ---
+
+    {% verbatim %}We can reference `{{ page.something.here.also }} === deep`.{% endverbatim %}
+
 ---
 
 ## A Sample Content Type

--- a/source/documentation/sources.md
+++ b/source/documentation/sources.md
@@ -4,38 +4,76 @@ slug: sources
 
 ---
 
-By default, sources are objects represented by each file under `source/`.
-Sources that have YAML frontmatter are considered special in that they can be
-formatted.
+By default, Sculpin assumes that there will be a directory named `source/` in your project's root folder containing all of the *content* for your site.
 
-What is YAML frontmatter? It is best to compare examples:
+If you are working from a project template, such as the Getting Started guide describes, your project will already have a `source` directory. If you are starting your project from scratch, you will need to create a source directory for the content of your site.
 
-    # This is a markdown file without YAML frontmatter
+    |-- source/
 
-... compared to...
+## Source Directories
+
+You may divide your content into sub-directories within the directory `source`. For example, you may want your blog posts to appear with the URL `blog`.
+
+    |-- source/
+    |  |-- blog/
+    |     |-- 2014-02-21-first-post.md
+    |     |-- 2014-03-21-time-management.md
+    |  |-- about.md
+    |  |-- contact.md
+
+When the HTML files are generated for your site, there will not be a one-to-one correlation between the source files, and the output HTML files. For this reason, you may want to store your source material in a folder with a different name than the output directory. The convention is to use a preceding underscore as this will put the directories alphabetically first. There is no requirement to use this naming convention.
+
+    |-- source/
+    |  |-- _posts/
+    |  |-- _pages/
+
+If you are using custom content types, using one directory per content type will also allow you to easily apply a custom template for each different content type without having to explicitly state which template the source file should use. This is handy to know about, even if you're not taking advantage of it immediately.
+
+Information on how to map a source directory to a specific output directory is included in the page on [Configuration]({{site.url}}/documentation/configuration/).
+    
+## Formatting Source Files
+
+Content source files for Sculpin projects are markdown files, with an optional YAML frontmatter header. The YAML frontmatter is delimited
+by `---`. For example:
 
     ---
-    layout: default
+    title: Hello World
     ---
 
-    # This is a markdown file with YAML frontmatter
+    This is the content of my page.
 
-As you can see, there is a chunk of YAML in the second example. It is delimited
-by `---`. The YAML frontmatter is parsed and injected into every page rendering
-and is accessible as `page.KEY`.
+Any variables contained in the YAML frontmatter are used, as appropriate, by the view for each content type. As such, the frontmatter is not rendered to the HTML page unless it is explicitly requested by the view template. This means that a page title contained in the YAML frontmatter will not be displayed unless it is explicitly requested by the view for that particular content type. Although you can write plain markdown without the YAML frontmatter, you are advised against doing this as it will omit the HTML element for the page tag `<title>`, which isn't very SEO-friendly.
+
+    # Hello World
+
+    This is the content of my page. But it's not very SEO-friendly because it's missing the HTML element <title>.
+
+There is more information about using frontmatter variables in [Custom Content Types]({{site.url}}/documentation/content-types/custom-types/).
 
 
-## Deep Frontmatter YAML Structures
+## Rendered Source Files 
 
-Sculpin will read deep structures in YAML frontmatter. Just use a `.` to
-indicate that you want to descend into a structure. For example:
+Your markdown files will automatically be converted to `.html` files when  generating the output for your site.
 
-    ---
-    layout: default
-    something:
-        here:
-            very: deep
-            also: deep
-    ---
+For example: let's say you have only one source file, `index.md`:
 
-    {% verbatim %}We can reference `{{ page.something.here.also }} === deep`.{% endverbatim %}
+    |-- source/
+       `-- index.md
+
+After generating your content for the dev environment with the command `sculpin generate --watch --server`, you will have the following directory structure:
+
+    |-- source/
+       `-- index.md
+    |-- output_dev/
+       `-- index.html
+
+After generating your content for the **production** environment with the command `sculpin generate --env=prod`, you will have the following directory structure:
+
+    |-- source/
+       `-- index.md
+    |-- output_dev/
+       `-- index.html
+    |-- output_prod/
+       `-- index.html
+
+You should upload the contents of the directory `output_prod` to your server. You do not need to upload the contents of the source directory, or the developer environment.


### PR DESCRIPTION
This should get a pretty careful read-through to make sure I've correctly understood how things work. I think the stuff you helped me with today in IRC fits into the custom content type page a little better and/or the configuration page. For starters: I want people to see that "raw" content goes into the directory `sources` and there are some things which need to be considered regarding directory names, and the YAML frontmatter.

Summary of changes:
- Removed most of the content from basic-project as it is now a
  duplicate of the getting started guide. Kept the directory
  structure, will add links from this file to relevant pages as they
  are created.
- Moved frontmatter YAML information to the custom content type page.
- Heavily modified the sources file to make it more about the
  the default format for this file, and how it will be output.
