### PR TITLE
Fix `sculpin_content_types`.`path` default

### DIFF
--- a/source/documentation/content-types/custom-types.md
+++ b/source/documentation/content-types/custom-types.md
@@ -37,8 +37,8 @@ the following keys are available:
    path or on some meta information.
  * **path**:
    If `type: path`, the path that will be used to locate this type. Defaults to
-   the singularized version of the type name with a `_` prepended. (so, for a
-   content type named `talks`, the default path would be `_talks`)
+   the type name with a `_` prepended. (so, for a content type named `talks`, 
+   the default path would be `_talks`)
  * **meta_key**:
    If `type: meta`, the meta key that will be used to locate this type. Defaults
    to the singularized version of the type name.


### PR DESCRIPTION
The default `path` value is just "_$type", from what I can tell.