### PR TITLE
Disabling 'posts' content type in sculpin_kernel

### DIFF
--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -2,3 +2,5 @@ sculpin_content_types:
     docs:
         path: documentation
         permalink: pretty
+    posts:
+        enabled: false


### PR DESCRIPTION
This is necessary in order to fix repeated "`Didnt find at least one of this type : posts`" notice