### PR TITLE
Add "Shopware Developer Documentation" to "Powered by Sculpin"

### DIFF
--- a/source/_views/includes/powered-by.html
+++ b/source/_views/includes/powered-by.html
@@ -189,5 +189,9 @@
         <div class="powered-by-site col-sm-6">
             <a class="title" href="http://m35dev.com">M35 Development</a>
         </div>
+        <div class="powered-by-site col-sm-6">
+            <a class="title" href="https://devdocs.shopware.com">Shopware Developer Documentation</a>
+            <a class="source" href="https://github.com/shopware/devdocs"><i class="icon icon-github"></i></a>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
For the new Shopware 5 Developer Documentation we used Sculpin to built the site.  