### PR TITLE
Updated jumbo text

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -10,7 +10,7 @@ nav_name: home
   <h1 class="sr-only">PHP Static Site Generator</h1>
 
   <p class="jumbo">
-    Sculpin is a <strong>static site generator</strong> written in <strong>PHP</strong>. It converts <strong>Markdown files</strong>, <strong>Twig templates</strong> or standard HTML into a <strong>static HTML site</strong> that can be <strong>easily deployed</strong>.
+    Sculpin is a <strong>static site generator</strong> written in <strong>PHP</strong>. It converts <strong>Markdown files</strong>, <strong>Twig templates</strong> and standard HTML into a <strong>static HTML site</strong> that can be <strong>easily deployed</strong>.
   </p>
 
   <br>


### PR DESCRIPTION
Sculpin can convert a multiple formats - HTML, Twig and Markdown, not just one as this text implies. In fact, you need two of these (i.e. HTML or Markdown, and Twig) to build a site, although I'm guessing that sites use a mixture of all three - mine does.