### PR TITLE
fix documentation for meta_key of custom type

### DIFF
--- a/source/documentation/content-types/custom-types.md
+++ b/source/documentation/content-types/custom-types.md
@@ -41,7 +41,7 @@ the following keys are available:
    the default path would be `_talks`)
  * **meta_key**:
    If `type: meta`, the meta key that will be used to locate this type. Defaults
-   to the singularized version of the type name.
+   to `type`.
  * **meta**:
    If `type: meta`, the value of the meta key that will be used to locate this
    type. Defaults to the singularized name.


### PR DESCRIPTION
i was a bit confused why it would want me to do `project: project` in the meta, then did not work, then looked through the source code to find this...