### PR TITLE
Clean up powered-by; organize by categories and remove stale entries

### DIFF
--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -123,286 +123,200 @@ powered site you'd like to have showcased here? Send a Pull Request to the
 GitHub!</p>
 
 <p><div class="powered-by">
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://sculpin.io/">Sculpin</a>
-            <a class="source" href="https://github.com/sculpin/sculpin.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://stackphp.com/">Stack</a>
-            <a class="source" href="https://github.com/stackphp/stackphp.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://henrik.bjrnskov.dk/">Henrik Bjrnskov</a>
-            <a class="source" href="https://github.com/henrikbjorn/henrik.bjrnskov.dk"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.gibsonindex.org/">Gibson Index</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://whateverthing.com/">whateverthing.com <i class="glyphicon glyphicon-send"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://wtboard.com/">wtBoard</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://2013.notrollsallowed.com/">No Trolls Allowed</a>
-            <a class="source" href="https://github.com/ntacamp/2013.notrollsallowed.com"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://offloc.com">Offloc</a>
-            <a class="source" href="https://github.com/offloc/offloc.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://srcmvn.com/">Source Maven</a>
-            <a class="source" href="https://github.com/simensen/srcmvn.com"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://mirrorquest.com/">Mirror Quest</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://beau.io/">beau.io</a>
-            <a class="source" href="https://github.com/simensen/beau.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://dflydev.com/">dflydev</a>
-            <a class="source" href="https://github.com/dflydev/dflydev.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://asm89.github.io/">asm89</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://labs.qandidate.com/">labs @ Qandidate.com</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://adrianschneider.ca">Adrian Schneider</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://thorpesystems.com">thorpesystems.com</a>
-            <a class="source" href="https://github.com/trq/blog-2013"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://holiday2013.palantir.net/">Palantir Holiday 2013</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://renemoser.net">renemoser.net</a>
-            <a class="source" href="https://github.com/resmo/renemoser.net"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://reflxlabsinc.com">REFLX Labs</a>
-            <a class="source" href="https://github.com/reflxlabs/reflxlabsinc.com"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://thatpodcast.io">That Podcast</a>
-            <a class="source" href="https://github.com/thatpodcast/thatpodcast.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://pauljones.io">Paul Jones</a>
-            <a class="source" href="https://bitbucket.org/pj/pauljones.io"><i class="icon icon-bitbucket"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.tsphethean.co.uk">tsphethean.co.uk</a>
-            <a class="source" href="https://github.com/tsphethean/blog"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://blog.andrewshell.org">Andrew Shell's Weblog</a>
-            <a class="source" href="https://github.com/andrewshell/blog.andrewshell.org"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://yottaram.com">Yottaram</a>
-            <a class="source" href="https://github.com/jonstavis/yottaram.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://sabre.io/">sabre/dav</a>
-            <a class="source" href="https://github.com/fruux/sabre.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://gushphp.org/">Gushphp</a>
-            <a class="source" href="https://github.com/gushphp/gush-site"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://bldr.io/">Bldr Task Runner</a>
-            <a class="source" href="https://github.com/bldr-io/bldr.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://snugnight.com/">Snug Night</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://liquidforms.io">Liquid Forms</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://st-gc.org">Seductive Turtle Gaming Community</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://coderabbi.github.io">coderabbi</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://markrailton.com">Mark Railton</a>
-            <a class="source" href="https://github.com/railto/railto.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.memphistechnology.org">Memphis Technology Foundation</a>
-            <a class="source" href="https://github.com/memtech/memphistechnology.org"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://fiveminutegeekshow.com">Five-Minute Geek Show</a>
-            <a class="source" href="https://github.com/FiveMinuteGeekShow/FiveMinuteGeekShow"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://shefphp.github.io">Sheffield PHP User Group</a>
-            <a class="source" href="https://github.com/ShefPHP/ShefPHP.github.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://blog.wyrihaximus.net/">Cees-Jan Kiewiet's blog</a>
-            <a class="source" href="https://github.com/WyriHaximus/blog.wyrihaximus.net"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://davedevelopment.co.uk">davedevelopment.co.uk</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://gabriela.io">gabriela.io</a>
-            <a class="source" href="http://github.com/gabidavila/gabriela.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://simplelance.com">SimpleLance</a>
-            <a class="source" href="https://github.com/SimpleLance/SimpleLance"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://naxoc.net">naxoc.net</a>
-            <a class="source" href="https://github.com/naxoc/sculpin-blog"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://m35dev.com">M35 Development</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://devdocs.shopware.com">Shopware Developer Documentation</a>
-            <a class="source" href="https://github.com/shopware/devdocs"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.oliverdavies.uk">oliverdavies.uk</a>
-            <a class="source" href="https://github.com/opdavies/oliverdavies.uk"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://future500.nl">Future500 B.V.</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://pantheon.io/docs">Pantheon Documentation</a>
-            <a class="source" href="https://github.com/pantheon-systems/documentation"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://alimac.io">alimac.io</a>
-            <a class="source" href="https://github.com/alimac/alimac.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://securepasswords.info">SecurePasswords.info</a>
-            <a class="source" href="https://github.com/dshafik/securepasswords.info"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://phergie.org/">Phergie.org</a>
-            <a class="source" href="https://github.com/phergie/phergie.org/"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.timbroder.com/">TimBroder.com</a>
-            <a class="source" href="https://github.com/broderboy/timbroder.com-sculpin/"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://dannyweeks.com">dannyweeks.com</a>
-            <a class="source" href="https://github.com/dannyweeks/dannyweeks.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://mozfr.org/">French Mozilla community</a>
-            <a class="source" href="https://github.com/mozfr/www"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://geocod.io">Geocod.io</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.ifdattic.com/">ifdattic.com</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://benplummer.uk">Ben Plummer</a>
-            <a class="source" href="https://github.com/benplummer/website"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://tekkie.ro/">Tekkie Consulting</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://tekkie.me">Georgiana Gligor</a>
-            <a class="source" href="https://github.com/georgiana-gligor/tekkie.me"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://blog.coderspirit.xyz">CoderSpirit.XYZ</a>
-            <a class="source" href="https://github.com/castarco/coderspirit.blog"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://rheinneckarrocks.de/">#rheinneckarrocks</a>
-            <a class="source" href="https://github.com/rheinneckarrocks/rheinneckarrocks.github.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.audiodog.co.uk">Audiodog</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://games.anthony-dessalles.com/">Anthony Dessalles' Games</a>
-        </div>
-    </div>
+    <h3>Company Sites</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="http://dflydev.com/">dflydev</a>
+        <a class="source" href="https://github.com/dflydev/dflydev.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://liquidforms.io">Liquid Forms</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://thorpesystems.com">thorpesystems.com</a>
+        <a class="source" href="https://github.com/trq/blog-2013"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://reflxlabsinc.com">REFLX Labs</a>
+        <a class="source" href="https://github.com/reflxlabs/reflxlabsinc.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://yottaram.com">Yottaram</a>
+        <a class="source" href="https://github.com/jonstavis/yottaram.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://future500.nl">Future500 B.V.</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://geocod.io">Geocod.io</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.ifdattic.com/">ifdattic.com</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://tekkie.ro/">Tekkie Consulting</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.audiodog.co.uk">Audiodog</a>
+    </li>
+    </ul>
+
+    <h3>Open Source Sites/Documentation</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="https://sculpin.io/">Sculpin</a>
+        <a class="source" href="https://github.com/sculpin/sculpin.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://stackphp.com/">Stack</a>
+        <a class="source" href="https://github.com/stackphp/stackphp.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://sabre.io/">sabre/dav</a>
+        <a class="source" href="https://github.com/fruux/sabre.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://bldr.io/">Bldr Task Runner</a>
+        <a class="source" href="https://github.com/bldr-io/bldr.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://devdocs.shopware.com">Shopware Developer Documentation</a>
+        <a class="source" href="https://github.com/shopware/devdocs"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://pantheon.io/docs">Pantheon Documentation</a>
+        <a class="source" href="https://github.com/pantheon-systems/documentation"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://securepasswords.info">SecurePasswords.info</a>
+        <a class="source" href="https://github.com/dshafik/securepasswords.info"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://phergie.org/">Phergie.org</a>
+        <a class="source" href="https://github.com/phergie/phergie.org/"><i class="icon icon-github"></i></a>
+    </li>
+    </ul>
+
+    <h3>Community Sites</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="http://2013.notrollsallowed.com/">No Trolls Allowed</a>
+        <a class="source" href="https://github.com/ntacamp/2013.notrollsallowed.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://holiday2013.palantir.net/">Palantir Holiday 2013</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://labs.qandidate.com/">labs @ Qandidate.com</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.memphistechnology.org">Memphis Technology Foundation</a>
+        <a class="source" href="https://github.com/memtech/memphistechnology.org"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://shefphp.github.io">Sheffield PHP User Group</a>
+        <a class="source" href="https://github.com/ShefPHP/ShefPHP.github.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://mozfr.org/">French Mozilla community</a>
+        <a class="source" href="https://github.com/mozfr/www"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://rheinneckarrocks.de/">#rheinneckarrocks</a>
+        <a class="source" href="https://github.com/rheinneckarrocks/rheinneckarrocks.github.io"><i class="icon icon-github"></i></a>
+    </li>
+    </ul>
+
+    <h3>Blogs/Personal Sites</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="http://whateverthing.com/">whateverthing.com</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://srcmvn.com/">Source Maven</a>
+        <a class="source" href="https://github.com/simensen/srcmvn.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://beau.io/">beau.io</a>
+        <a class="source" href="https://github.com/simensen/beau.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://asm89.github.io/">asm89</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://adrianschneider.ca">Adrian Schneider</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://blog.wyrihaximus.net/">Cees-Jan Kiewiet's blog</a>
+        <a class="source" href="https://github.com/WyriHaximus/blog.wyrihaximus.net"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://naxoc.net">naxoc.net</a>
+        <a class="source" href="https://github.com/naxoc/sculpin-blog"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.oliverdavies.uk">oliverdavies.uk</a>
+        <a class="source" href="https://github.com/opdavies/oliverdavies.uk"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://dannyweeks.com">dannyweeks.com</a>
+        <a class="source" href="https://github.com/dannyweeks/dannyweeks.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://benplummer.uk">Ben Plummer</a>
+        <a class="source" href="https://github.com/benplummer/website"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://tekkie.me">Georgiana Gligor</a>
+        <a class="source" href="https://github.com/georgiana-gligor/tekkie.me"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://blog.coderspirit.xyz">CoderSpirit.XYZ</a>
+        <a class="source" href="https://github.com/castarco/coderspirit.blog"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://games.anthony-dessalles.com/">Anthony Dessalles' Games</a>
+    </li>
+    </ul>
+
 </div>
 </p>
                     </div>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -227,14 +227,17 @@ footer.site .copyright {
 	font-weight: bold;
 }
 
-.powered-by .row a {
+.powered-by h3 {
+	text-align: center;
+	margin-top: 40px;
+	margin-bottom: 40px;
+}
+.powered-by ul li a {
 	text-decoration: none;
-	padding: .25em 0;
-	display: inline-block;
 }
 
 .powered-by .powered-by-site {
-	font-size: 1.5em;
+	font-size: 1.2em;
 }
 .powered-by .powered-by-site .title {
 }
@@ -244,16 +247,26 @@ footer.site .copyright {
 	font-size: .75em;
 }
 
-.powered-by .powered-by-site .source {
-	color: #C0CFD5;
+.powered-by ul.list-inline {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+	grid-gap: 2vw;
 }
-.powered-by .powered-by-site .source:hover {
-	color: #DFE7EA;
+.powered-by li.powered-by-site {
+	padding: .5em;
+	text-align: left;
 }
 
 .powered-by .powered-by-site .icon-github:after,
 .powered-by .powered-by-site .icon-bitbucket:after {
 	content: " src";
+}
+
+.powered-by .powered-by-site .source {
+	color: #C0CFD5;
+}
+.powered-by .powered-by-site .source:hover {
+	color: #DFE7EA;
 }
 
 
@@ -550,7 +563,7 @@ only screen and (                min-resolution: 2dppx)  and (min-width: 480px) 
 	}
 
 	.marketing .powered-by .powered-by-site {
-		font-size: 1em;
+		font-size: .6em;
 	}
 
 	footer.site .mascot {

--- a/docs/index.html
+++ b/docs/index.html
@@ -124,7 +124,7 @@
 
   <p>Ready for a taste of Sculpin? Check out the <strong><a href="https://sculpin.io/getstarted/">Quick Start Guide!</a></strong></p>
 
-  <p class="bg-info">
+  <p>
     Advanced users can jump directly into a Sculpin project using Composer and the Sculpin Blog Skeleton:
     <blockquote>
     <code style="background-color: transparent;">
@@ -149,286 +149,200 @@
     Here is a quick sampling of Sculpin powered sites in the wild. Have a Sculpin powered site you'd like to have showcased here? Send a Pull Request to the <a href="https://github.com/sculpin/sculpin.io">sculpin.io</a> repository on GitHub, or reach out to <strong><a href="https://twitter.com/getsculpin">@getsculpin</a></strong> on Twitter!
   </p>
   <div class="powered-by">
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://sculpin.io/">Sculpin</a>
-            <a class="source" href="https://github.com/sculpin/sculpin.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://stackphp.com/">Stack</a>
-            <a class="source" href="https://github.com/stackphp/stackphp.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://henrik.bjrnskov.dk/">Henrik Bjrnskov</a>
-            <a class="source" href="https://github.com/henrikbjorn/henrik.bjrnskov.dk"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.gibsonindex.org/">Gibson Index</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://whateverthing.com/">whateverthing.com <i class="glyphicon glyphicon-send"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://wtboard.com/">wtBoard</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://2013.notrollsallowed.com/">No Trolls Allowed</a>
-            <a class="source" href="https://github.com/ntacamp/2013.notrollsallowed.com"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://offloc.com">Offloc</a>
-            <a class="source" href="https://github.com/offloc/offloc.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://srcmvn.com/">Source Maven</a>
-            <a class="source" href="https://github.com/simensen/srcmvn.com"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://mirrorquest.com/">Mirror Quest</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://beau.io/">beau.io</a>
-            <a class="source" href="https://github.com/simensen/beau.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://dflydev.com/">dflydev</a>
-            <a class="source" href="https://github.com/dflydev/dflydev.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://asm89.github.io/">asm89</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://labs.qandidate.com/">labs @ Qandidate.com</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://adrianschneider.ca">Adrian Schneider</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://thorpesystems.com">thorpesystems.com</a>
-            <a class="source" href="https://github.com/trq/blog-2013"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://holiday2013.palantir.net/">Palantir Holiday 2013</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://renemoser.net">renemoser.net</a>
-            <a class="source" href="https://github.com/resmo/renemoser.net"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://reflxlabsinc.com">REFLX Labs</a>
-            <a class="source" href="https://github.com/reflxlabs/reflxlabsinc.com"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://thatpodcast.io">That Podcast</a>
-            <a class="source" href="https://github.com/thatpodcast/thatpodcast.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://pauljones.io">Paul Jones</a>
-            <a class="source" href="https://bitbucket.org/pj/pauljones.io"><i class="icon icon-bitbucket"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.tsphethean.co.uk">tsphethean.co.uk</a>
-            <a class="source" href="https://github.com/tsphethean/blog"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://blog.andrewshell.org">Andrew Shell's Weblog</a>
-            <a class="source" href="https://github.com/andrewshell/blog.andrewshell.org"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://yottaram.com">Yottaram</a>
-            <a class="source" href="https://github.com/jonstavis/yottaram.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://sabre.io/">sabre/dav</a>
-            <a class="source" href="https://github.com/fruux/sabre.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://gushphp.org/">Gushphp</a>
-            <a class="source" href="https://github.com/gushphp/gush-site"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://bldr.io/">Bldr Task Runner</a>
-            <a class="source" href="https://github.com/bldr-io/bldr.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://snugnight.com/">Snug Night</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://liquidforms.io">Liquid Forms</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://st-gc.org">Seductive Turtle Gaming Community</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://coderabbi.github.io">coderabbi</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://markrailton.com">Mark Railton</a>
-            <a class="source" href="https://github.com/railto/railto.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.memphistechnology.org">Memphis Technology Foundation</a>
-            <a class="source" href="https://github.com/memtech/memphistechnology.org"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://fiveminutegeekshow.com">Five-Minute Geek Show</a>
-            <a class="source" href="https://github.com/FiveMinuteGeekShow/FiveMinuteGeekShow"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://shefphp.github.io">Sheffield PHP User Group</a>
-            <a class="source" href="https://github.com/ShefPHP/ShefPHP.github.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://blog.wyrihaximus.net/">Cees-Jan Kiewiet's blog</a>
-            <a class="source" href="https://github.com/WyriHaximus/blog.wyrihaximus.net"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://davedevelopment.co.uk">davedevelopment.co.uk</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://gabriela.io">gabriela.io</a>
-            <a class="source" href="http://github.com/gabidavila/gabriela.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://simplelance.com">SimpleLance</a>
-            <a class="source" href="https://github.com/SimpleLance/SimpleLance"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://naxoc.net">naxoc.net</a>
-            <a class="source" href="https://github.com/naxoc/sculpin-blog"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://m35dev.com">M35 Development</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://devdocs.shopware.com">Shopware Developer Documentation</a>
-            <a class="source" href="https://github.com/shopware/devdocs"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.oliverdavies.uk">oliverdavies.uk</a>
-            <a class="source" href="https://github.com/opdavies/oliverdavies.uk"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://future500.nl">Future500 B.V.</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://pantheon.io/docs">Pantheon Documentation</a>
-            <a class="source" href="https://github.com/pantheon-systems/documentation"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://alimac.io">alimac.io</a>
-            <a class="source" href="https://github.com/alimac/alimac.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://securepasswords.info">SecurePasswords.info</a>
-            <a class="source" href="https://github.com/dshafik/securepasswords.info"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://phergie.org/">Phergie.org</a>
-            <a class="source" href="https://github.com/phergie/phergie.org/"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.timbroder.com/">TimBroder.com</a>
-            <a class="source" href="https://github.com/broderboy/timbroder.com-sculpin/"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://dannyweeks.com">dannyweeks.com</a>
-            <a class="source" href="https://github.com/dannyweeks/dannyweeks.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://mozfr.org/">French Mozilla community</a>
-            <a class="source" href="https://github.com/mozfr/www"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://geocod.io">Geocod.io</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.ifdattic.com/">ifdattic.com</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://benplummer.uk">Ben Plummer</a>
-            <a class="source" href="https://github.com/benplummer/website"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://tekkie.ro/">Tekkie Consulting</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://tekkie.me">Georgiana Gligor</a>
-            <a class="source" href="https://github.com/georgiana-gligor/tekkie.me"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://blog.coderspirit.xyz">CoderSpirit.XYZ</a>
-            <a class="source" href="https://github.com/castarco/coderspirit.blog"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://rheinneckarrocks.de/">#rheinneckarrocks</a>
-            <a class="source" href="https://github.com/rheinneckarrocks/rheinneckarrocks.github.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.audiodog.co.uk">Audiodog</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://games.anthony-dessalles.com/">Anthony Dessalles' Games</a>
-        </div>
-    </div>
+    <h3>Company Sites</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="http://dflydev.com/">dflydev</a>
+        <a class="source" href="https://github.com/dflydev/dflydev.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://liquidforms.io">Liquid Forms</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://thorpesystems.com">thorpesystems.com</a>
+        <a class="source" href="https://github.com/trq/blog-2013"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://reflxlabsinc.com">REFLX Labs</a>
+        <a class="source" href="https://github.com/reflxlabs/reflxlabsinc.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://yottaram.com">Yottaram</a>
+        <a class="source" href="https://github.com/jonstavis/yottaram.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://future500.nl">Future500 B.V.</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://geocod.io">Geocod.io</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.ifdattic.com/">ifdattic.com</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://tekkie.ro/">Tekkie Consulting</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.audiodog.co.uk">Audiodog</a>
+    </li>
+    </ul>
+
+    <h3>Open Source Sites/Documentation</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="https://sculpin.io/">Sculpin</a>
+        <a class="source" href="https://github.com/sculpin/sculpin.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://stackphp.com/">Stack</a>
+        <a class="source" href="https://github.com/stackphp/stackphp.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://sabre.io/">sabre/dav</a>
+        <a class="source" href="https://github.com/fruux/sabre.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://bldr.io/">Bldr Task Runner</a>
+        <a class="source" href="https://github.com/bldr-io/bldr.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://devdocs.shopware.com">Shopware Developer Documentation</a>
+        <a class="source" href="https://github.com/shopware/devdocs"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://pantheon.io/docs">Pantheon Documentation</a>
+        <a class="source" href="https://github.com/pantheon-systems/documentation"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://securepasswords.info">SecurePasswords.info</a>
+        <a class="source" href="https://github.com/dshafik/securepasswords.info"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://phergie.org/">Phergie.org</a>
+        <a class="source" href="https://github.com/phergie/phergie.org/"><i class="icon icon-github"></i></a>
+    </li>
+    </ul>
+
+    <h3>Community Sites</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="http://2013.notrollsallowed.com/">No Trolls Allowed</a>
+        <a class="source" href="https://github.com/ntacamp/2013.notrollsallowed.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://holiday2013.palantir.net/">Palantir Holiday 2013</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://labs.qandidate.com/">labs @ Qandidate.com</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.memphistechnology.org">Memphis Technology Foundation</a>
+        <a class="source" href="https://github.com/memtech/memphistechnology.org"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://shefphp.github.io">Sheffield PHP User Group</a>
+        <a class="source" href="https://github.com/ShefPHP/ShefPHP.github.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://mozfr.org/">French Mozilla community</a>
+        <a class="source" href="https://github.com/mozfr/www"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://rheinneckarrocks.de/">#rheinneckarrocks</a>
+        <a class="source" href="https://github.com/rheinneckarrocks/rheinneckarrocks.github.io"><i class="icon icon-github"></i></a>
+    </li>
+    </ul>
+
+    <h3>Blogs/Personal Sites</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="http://whateverthing.com/">whateverthing.com</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://srcmvn.com/">Source Maven</a>
+        <a class="source" href="https://github.com/simensen/srcmvn.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://beau.io/">beau.io</a>
+        <a class="source" href="https://github.com/simensen/beau.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://asm89.github.io/">asm89</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://adrianschneider.ca">Adrian Schneider</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://blog.wyrihaximus.net/">Cees-Jan Kiewiet's blog</a>
+        <a class="source" href="https://github.com/WyriHaximus/blog.wyrihaximus.net"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://naxoc.net">naxoc.net</a>
+        <a class="source" href="https://github.com/naxoc/sculpin-blog"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.oliverdavies.uk">oliverdavies.uk</a>
+        <a class="source" href="https://github.com/opdavies/oliverdavies.uk"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://dannyweeks.com">dannyweeks.com</a>
+        <a class="source" href="https://github.com/dannyweeks/dannyweeks.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://benplummer.uk">Ben Plummer</a>
+        <a class="source" href="https://github.com/benplummer/website"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://tekkie.me">Georgiana Gligor</a>
+        <a class="source" href="https://github.com/georgiana-gligor/tekkie.me"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://blog.coderspirit.xyz">CoderSpirit.XYZ</a>
+        <a class="source" href="https://github.com/castarco/coderspirit.blog"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://games.anthony-dessalles.com/">Anthony Dessalles' Games</a>
+    </li>
+    </ul>
+
 </div>
 
 </div>

--- a/source/_views/includes/powered-by.html
+++ b/source/_views/includes/powered-by.html
@@ -1,282 +1,196 @@
 <div class="powered-by">
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://sculpin.io/">Sculpin</a>
-            <a class="source" href="https://github.com/sculpin/sculpin.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://stackphp.com/">Stack</a>
-            <a class="source" href="https://github.com/stackphp/stackphp.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://henrik.bjrnskov.dk/">Henrik Bjrnskov</a>
-            <a class="source" href="https://github.com/henrikbjorn/henrik.bjrnskov.dk"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.gibsonindex.org/">Gibson Index</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://whateverthing.com/">whateverthing.com <i class="glyphicon glyphicon-send"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://wtboard.com/">wtBoard</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://2013.notrollsallowed.com/">No Trolls Allowed</a>
-            <a class="source" href="https://github.com/ntacamp/2013.notrollsallowed.com"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://offloc.com">Offloc</a>
-            <a class="source" href="https://github.com/offloc/offloc.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://srcmvn.com/">Source Maven</a>
-            <a class="source" href="https://github.com/simensen/srcmvn.com"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://mirrorquest.com/">Mirror Quest</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://beau.io/">beau.io</a>
-            <a class="source" href="https://github.com/simensen/beau.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://dflydev.com/">dflydev</a>
-            <a class="source" href="https://github.com/dflydev/dflydev.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://asm89.github.io/">asm89</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://labs.qandidate.com/">labs @ Qandidate.com</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://adrianschneider.ca">Adrian Schneider</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://thorpesystems.com">thorpesystems.com</a>
-            <a class="source" href="https://github.com/trq/blog-2013"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://holiday2013.palantir.net/">Palantir Holiday 2013</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://renemoser.net">renemoser.net</a>
-            <a class="source" href="https://github.com/resmo/renemoser.net"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://reflxlabsinc.com">REFLX Labs</a>
-            <a class="source" href="https://github.com/reflxlabs/reflxlabsinc.com"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://thatpodcast.io">That Podcast</a>
-            <a class="source" href="https://github.com/thatpodcast/thatpodcast.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://pauljones.io">Paul Jones</a>
-            <a class="source" href="https://bitbucket.org/pj/pauljones.io"><i class="icon icon-bitbucket"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.tsphethean.co.uk">tsphethean.co.uk</a>
-            <a class="source" href="https://github.com/tsphethean/blog"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://blog.andrewshell.org">Andrew Shell's Weblog</a>
-            <a class="source" href="https://github.com/andrewshell/blog.andrewshell.org"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://yottaram.com">Yottaram</a>
-            <a class="source" href="https://github.com/jonstavis/yottaram.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://sabre.io/">sabre/dav</a>
-            <a class="source" href="https://github.com/fruux/sabre.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://gushphp.org/">Gushphp</a>
-            <a class="source" href="https://github.com/gushphp/gush-site"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://bldr.io/">Bldr Task Runner</a>
-            <a class="source" href="https://github.com/bldr-io/bldr.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://snugnight.com/">Snug Night</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://liquidforms.io">Liquid Forms</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://st-gc.org">Seductive Turtle Gaming Community</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://coderabbi.github.io">coderabbi</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://markrailton.com">Mark Railton</a>
-            <a class="source" href="https://github.com/railto/railto.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.memphistechnology.org">Memphis Technology Foundation</a>
-            <a class="source" href="https://github.com/memtech/memphistechnology.org"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://fiveminutegeekshow.com">Five-Minute Geek Show</a>
-            <a class="source" href="https://github.com/FiveMinuteGeekShow/FiveMinuteGeekShow"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://shefphp.github.io">Sheffield PHP User Group</a>
-            <a class="source" href="https://github.com/ShefPHP/ShefPHP.github.io"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://blog.wyrihaximus.net/">Cees-Jan Kiewiet's blog</a>
-            <a class="source" href="https://github.com/WyriHaximus/blog.wyrihaximus.net"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://davedevelopment.co.uk">davedevelopment.co.uk</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://gabriela.io">gabriela.io</a>
-            <a class="source" href="http://github.com/gabidavila/gabriela.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://simplelance.com">SimpleLance</a>
-            <a class="source" href="https://github.com/SimpleLance/SimpleLance"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://naxoc.net">naxoc.net</a>
-            <a class="source" href="https://github.com/naxoc/sculpin-blog"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://m35dev.com">M35 Development</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://devdocs.shopware.com">Shopware Developer Documentation</a>
-            <a class="source" href="https://github.com/shopware/devdocs"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.oliverdavies.uk">oliverdavies.uk</a>
-            <a class="source" href="https://github.com/opdavies/oliverdavies.uk"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://future500.nl">Future500 B.V.</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://pantheon.io/docs">Pantheon Documentation</a>
-            <a class="source" href="https://github.com/pantheon-systems/documentation"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://alimac.io">alimac.io</a>
-            <a class="source" href="https://github.com/alimac/alimac.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://securepasswords.info">SecurePasswords.info</a>
-            <a class="source" href="https://github.com/dshafik/securepasswords.info"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://phergie.org/">Phergie.org</a>
-            <a class="source" href="https://github.com/phergie/phergie.org/"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.timbroder.com/">TimBroder.com</a>
-            <a class="source" href="https://github.com/broderboy/timbroder.com-sculpin/"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://dannyweeks.com">dannyweeks.com</a>
-            <a class="source" href="https://github.com/dannyweeks/dannyweeks.com"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://mozfr.org/">French Mozilla community</a>
-            <a class="source" href="https://github.com/mozfr/www"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://geocod.io">Geocod.io</a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.ifdattic.com/">ifdattic.com</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://benplummer.uk">Ben Plummer</a>
-            <a class="source" href="https://github.com/benplummer/website"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://tekkie.ro/">Tekkie Consulting</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="https://tekkie.me">Georgiana Gligor</a>
-            <a class="source" href="https://github.com/georgiana-gligor/tekkie.me"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://blog.coderspirit.xyz">CoderSpirit.XYZ</a>
-            <a class="source" href="https://github.com/castarco/coderspirit.blog"><i class="icon icon-github"></i></a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://rheinneckarrocks.de/">#rheinneckarrocks</a>
-            <a class="source" href="https://github.com/rheinneckarrocks/rheinneckarrocks.github.io"><i class="icon icon-github"></i></a>
-        </div>
-    </div>
-    <div class="row">
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://www.audiodog.co.uk">Audiodog</a>
-        </div>
-        <div class="powered-by-site col-sm-6">
-            <a class="title" href="http://games.anthony-dessalles.com/">Anthony Dessalles' Games</a>
-        </div>
-    </div>
+    <h3>Company Sites</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="http://dflydev.com/">dflydev</a>
+        <a class="source" href="https://github.com/dflydev/dflydev.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://liquidforms.io">Liquid Forms</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://thorpesystems.com">thorpesystems.com</a>
+        <a class="source" href="https://github.com/trq/blog-2013"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://reflxlabsinc.com">REFLX Labs</a>
+        <a class="source" href="https://github.com/reflxlabs/reflxlabsinc.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://yottaram.com">Yottaram</a>
+        <a class="source" href="https://github.com/jonstavis/yottaram.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://future500.nl">Future500 B.V.</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://geocod.io">Geocod.io</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.ifdattic.com/">ifdattic.com</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://tekkie.ro/">Tekkie Consulting</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.audiodog.co.uk">Audiodog</a>
+    </li>
+    </ul>
+
+    <h3>Open Source Sites/Documentation</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="https://sculpin.io/">Sculpin</a>
+        <a class="source" href="https://github.com/sculpin/sculpin.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://stackphp.com/">Stack</a>
+        <a class="source" href="https://github.com/stackphp/stackphp.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://sabre.io/">sabre/dav</a>
+        <a class="source" href="https://github.com/fruux/sabre.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://bldr.io/">Bldr Task Runner</a>
+        <a class="source" href="https://github.com/bldr-io/bldr.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://devdocs.shopware.com">Shopware Developer Documentation</a>
+        <a class="source" href="https://github.com/shopware/devdocs"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://pantheon.io/docs">Pantheon Documentation</a>
+        <a class="source" href="https://github.com/pantheon-systems/documentation"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://securepasswords.info">SecurePasswords.info</a>
+        <a class="source" href="https://github.com/dshafik/securepasswords.info"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://phergie.org/">Phergie.org</a>
+        <a class="source" href="https://github.com/phergie/phergie.org/"><i class="icon icon-github"></i></a>
+    </li>
+    </ul>
+
+    <h3>Community Sites</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="http://2013.notrollsallowed.com/">No Trolls Allowed</a>
+        <a class="source" href="https://github.com/ntacamp/2013.notrollsallowed.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://holiday2013.palantir.net/">Palantir Holiday 2013</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://labs.qandidate.com/">labs @ Qandidate.com</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.memphistechnology.org">Memphis Technology Foundation</a>
+        <a class="source" href="https://github.com/memtech/memphistechnology.org"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://shefphp.github.io">Sheffield PHP User Group</a>
+        <a class="source" href="https://github.com/ShefPHP/ShefPHP.github.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://mozfr.org/">French Mozilla community</a>
+        <a class="source" href="https://github.com/mozfr/www"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://rheinneckarrocks.de/">#rheinneckarrocks</a>
+        <a class="source" href="https://github.com/rheinneckarrocks/rheinneckarrocks.github.io"><i class="icon icon-github"></i></a>
+    </li>
+    </ul>
+
+    <h3>Blogs/Personal Sites</h3>
+
+    <ul class="list-inline">
+    <li class="powered-by-site">
+        <a class="title" href="http://whateverthing.com/">whateverthing.com</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://srcmvn.com/">Source Maven</a>
+        <a class="source" href="https://github.com/simensen/srcmvn.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://beau.io/">beau.io</a>
+        <a class="source" href="https://github.com/simensen/beau.io"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://asm89.github.io/">asm89</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://adrianschneider.ca">Adrian Schneider</a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://blog.wyrihaximus.net/">Cees-Jan Kiewiet's blog</a>
+        <a class="source" href="https://github.com/WyriHaximus/blog.wyrihaximus.net"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://naxoc.net">naxoc.net</a>
+        <a class="source" href="https://github.com/naxoc/sculpin-blog"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://www.oliverdavies.uk">oliverdavies.uk</a>
+        <a class="source" href="https://github.com/opdavies/oliverdavies.uk"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://dannyweeks.com">dannyweeks.com</a>
+        <a class="source" href="https://github.com/dannyweeks/dannyweeks.com"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://benplummer.uk">Ben Plummer</a>
+        <a class="source" href="https://github.com/benplummer/website"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="https://tekkie.me">Georgiana Gligor</a>
+        <a class="source" href="https://github.com/georgiana-gligor/tekkie.me"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://blog.coderspirit.xyz">CoderSpirit.XYZ</a>
+        <a class="source" href="https://github.com/castarco/coderspirit.blog"><i class="icon icon-github"></i></a>
+    </li>
+
+    <li class="powered-by-site">
+        <a class="title" href="http://games.anthony-dessalles.com/">Anthony Dessalles' Games</a>
+    </li>
+    </ul>
+
 </div>

--- a/source/css/style.css
+++ b/source/css/style.css
@@ -227,14 +227,17 @@ footer.site .copyright {
 	font-weight: bold;
 }
 
-.powered-by .row a {
+.powered-by h3 {
+	text-align: center;
+	margin-top: 40px;
+	margin-bottom: 40px;
+}
+.powered-by ul li a {
 	text-decoration: none;
-	padding: .25em 0;
-	display: inline-block;
 }
 
 .powered-by .powered-by-site {
-	font-size: 1.5em;
+	font-size: 1.2em;
 }
 .powered-by .powered-by-site .title {
 }
@@ -244,16 +247,26 @@ footer.site .copyright {
 	font-size: .75em;
 }
 
-.powered-by .powered-by-site .source {
-	color: #C0CFD5;
+.powered-by ul.list-inline {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+	grid-gap: 2vw;
 }
-.powered-by .powered-by-site .source:hover {
-	color: #DFE7EA;
+.powered-by li.powered-by-site {
+	padding: .5em;
+	text-align: left;
 }
 
 .powered-by .powered-by-site .icon-github:after,
 .powered-by .powered-by-site .icon-bitbucket:after {
 	content: " src";
+}
+
+.powered-by .powered-by-site .source {
+	color: #C0CFD5;
+}
+.powered-by .powered-by-site .source:hover {
+	color: #DFE7EA;
 }
 
 
@@ -550,7 +563,7 @@ only screen and (                min-resolution: 2dppx)  and (min-width: 480px) 
 	}
 
 	.marketing .powered-by .powered-by-site {
-		font-size: 1em;
+		font-size: .6em;
 	}
 
 	footer.site .mascot {


### PR DESCRIPTION
The powered-by list needed an overhaul. This PR removes a bunch of entries that seemed to no longer be using sculpin, and it reorganizes the list into categories.