### PR TITLE
List community-made Sculpin extensions

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -65,6 +65,10 @@ docs:
                 url: documentation/extending-sculpin/creating-bundles/
                 slug: extending-sculpin/creating-bundles
             -
+                name: Community Extensions
+                url: documentation/extending-sculpin/community-extensions/
+                slug: extending-sculpin/community-extensions
+            -
                 name: Lifecycle
                 url: documentation/extending-sculpin/lifecycle/
                 slug: extending-sculpin/lifecycle

--- a/docs/documentation/basic-project/index.html
+++ b/docs/documentation/basic-project/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/configuration/index.html
+++ b/docs/documentation/configuration/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/content-types/custom-types/index.html
+++ b/docs/documentation/content-types/custom-types/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/content-types/index.html
+++ b/docs/documentation/content-types/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/converters/index.html
+++ b/docs/documentation/converters/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/extending-sculpin/community-extensions/index.html
+++ b/docs/documentation/extending-sculpin/community-extensions/index.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-        <title>Posts &mdash; Sculpin &mdash; PHP Static Site Generator</title>
+        <title>Community Extensions &mdash; Sculpin &mdash; PHP Static Site Generator</title>
         <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="icon" href="https://sculpin.io/favicon.ico">
     <link rel="stylesheet" href="https://sculpin.io/components/bootstrap/css/bootstrap.min.css">
@@ -101,7 +101,7 @@
 													</li>
 											<li ><a href="https://sculpin.io/documentation/content-types/">Content Types</a>
 															<ul class="nav">
-																			<li  class="active" ><a href="https://sculpin.io/documentation/content-types/posts/">Posts</a>
+																			<li ><a href="https://sculpin.io/documentation/content-types/posts/">Posts</a>
 																			<li ><a href="https://sculpin.io/documentation/content-types/custom-types/">Custom Types</a>
 																	</ul>
 													</li>
@@ -109,7 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
-																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
+																			<li  class="active" ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>
@@ -117,38 +117,71 @@
 			</div>
 		</div>
 		<div class="col-sm-9">
-			<h1>Posts</h1>
-            <p>Posts are a blog entry style content type that is enabled by default for every
-Sculpin project. The default configuration can be seen below:</p>
+			<h1>Community Extensions</h1>
+            <p>Community-made extensions are a great way to extend the capabilities of
+your Sculpin site.</p>
 
-<pre><code>sculpin_content_types:
-    posts:
-        type: path
-        path: _posts
-        permalink: pretty
-        taxonomies:
-            - tags
-            - categories
+<blockquote>
+Know of an extension that belongs on this list? Send a Pull
+Request to the <a href="https://github.com/sculpin/sculpin.io">
+sculpin.io</a> repository on GitHub, or reach out to <strong><a
+href="https://twitter.com/getsculpin">@getsculpin</a></strong> on
+Twitter!
+</blockquote>
+
+<p><strong><a href="https://packagist.org/packages/janbuecker/sculpin-meta-navigation-bundle">Meta Navigation Bundle</a></strong></p>
+
+<p>This extension helps you build navigation menus for your site.</p>
+
+<p>To make a menu item visible, add a <code>menu_title</code> entry to the page's
+front matter.</p>
+
+<p>Then, loop on <code>page.menu</code> to produce your menu, allowing up to
+3 levels of depth.</p>
+
+<p><strong><a href="https://packagist.org/packages/beryllium/icelus">Icelus Thumbnail Generator</a></strong></p>
+
+<p>Generate thumbnails from within Twig:</p>
+
+<pre><code>
+&lt;a href="image.jpg"&gt;&lt;img src="{{ thumbnail('image.jpg', 100, 100) }}"&gt;&lt;/a&gt;
+
 </code></pre>
 
-<p>Posts will be found in <code>_posts</code> inside of your <code>source</code> directory. The default
-permalink strategy is <code>pretty</code> and two taxonomies are supported, <code>tags</code> and
-<code>categories</code>.</p>
+<p><strong><a href="https://packagist.org/packages/tsphethean/sculpin-related-posts-bundle">Related Posts Bundle</a></strong></p>
 
-<p>In order to override these settings, you can modify
-<code>app/config/sculpin_kernel.yml</code>. For example, to set the permalink strategy to
-something else, you could change your local <code>sculpin_kernel.yml</code> to:</p>
+<p>List five related posts (based on tag and category correlations) below
+any given post:</p>
 
-<pre><code>sculpin_content_types:
-    posts:
-        permalink: blog/:year/:month/:day/:filename/
+<pre><code>
+{% if page.related %}
+&lt;ul&gt;
+  {% for relate in page.related %}
+  &lt;li&gt;&lt;a href="{{ relate.source.url }}"&gt;{{ relate.title }}&lt;/a&gt;&lt;/li&gt;
+  {% endfor %}
+&lt;/ul&gt;
+{% endif %}
+
 </code></pre>
 
-<p>To disable posts entirely, you would do:</p>
+<p><strong><a href="https://packagist.org/packages/opdavies/sculpin-twig-markdown-bundle">Twig Markdown Bundle</a></strong></p>
 
-<pre><code>sculpin_content_types:
-    posts:
-        enabled: false
+<p>Process markdown strings from within Twig:</p>
+
+<pre><code>
+{{ some_content|markdown }}
+
+</code></pre>
+
+<p><strong><a href="https://packagist.org/packages/opdavies/sculpin-twig-sort-by-field-bundle">Sort By Field Bundle</a></strong></p>
+
+<p>From within Twig, allows you to sort arrays by key:</p>
+
+<pre><code>
+{% for i in myArray | sortbyfield('array_sort_key') %}
+  {{ i.array_sort_key }}
+{% endfor %}
+
 </code></pre>
         </div>
     </div>

--- a/docs/documentation/extending-sculpin/configuration/index.html
+++ b/docs/documentation/extending-sculpin/configuration/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li  class="active" ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/extending-sculpin/creating-bundles/index.html
+++ b/docs/documentation/extending-sculpin/creating-bundles/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li  class="active" ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>
@@ -124,6 +125,9 @@ really is not much more to extending Sculpin that writing Symfony 2 bundles
 that hook into <a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Sculpin's event lifecycle</a>.</p>
 
 <p>Register your own bundles as described in the <a href="https://sculpin.io/documentation/extending-sculpin/configuration/">configuration</a> section.</p>
+
+<p>You may find it helpful to look at the existing <a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">community extensions</a>
+for inspiration and examples.</p>
         </div>
     </div>
         </div>

--- a/docs/documentation/extending-sculpin/index.html
+++ b/docs/documentation/extending-sculpin/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>
@@ -128,6 +129,10 @@ that Symfony uses.</p>
 <h2 id="creating-bundles2"><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a></h2>
 
 <p>Learn how to <a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">create a Sculpin bundle</a>.</p>
+
+<h2 id="community-extensions4"><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a></h2>
+
+<p>See a list of available <a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">community-made Sculpin extensions</a>.</p>
 
 <h2 id="lifecycle3"><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a></h2>
 

--- a/docs/documentation/extending-sculpin/lifecycle/index.html
+++ b/docs/documentation/extending-sculpin/lifecycle/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li  class="active" ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/formatters/index.html
+++ b/docs/documentation/formatters/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/generators/index.html
+++ b/docs/documentation/generators/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/layouts/index.html
+++ b/docs/documentation/layouts/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/sources/index.html
+++ b/docs/documentation/sources/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/documentation/themes/index.html
+++ b/docs/documentation/themes/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/docs/getstarted/index.html
+++ b/docs/getstarted/index.html
@@ -109,6 +109,7 @@
 															<ul class="nav">
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/configuration/">Configuration</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/creating-bundles/">Creating Bundles</a>
+																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/community-extensions/">Community Extensions</a>
 																			<li ><a href="https://sculpin.io/documentation/extending-sculpin/lifecycle/">Lifecycle</a>
 																	</ul>
 													</li>

--- a/source/documentation/extending-sculpin.md
+++ b/source/documentation/extending-sculpin.md
@@ -16,6 +16,10 @@ Learn how to [configure Sculpin][1] to use new bundles.
 
 Learn how to [create a Sculpin bundle][2].
 
+## [Community Extensions][4]
+
+See a list of available [community-made Sculpin extensions][4].
+
 ## [Lifecycle][3]
 
 Learn about [Sculpin's lifecycle][3] and the events you can use to build your
@@ -24,3 +28,4 @@ extensions.
 [1]: {{site.url}}/documentation/extending-sculpin/configuration/
 [2]: {{site.url}}/documentation/extending-sculpin/creating-bundles/
 [3]: {{site.url}}/documentation/extending-sculpin/lifecycle/
+[4]: {{site.url}}/documentation/extending-sculpin/community-extensions/

--- a/source/documentation/extending-sculpin/community-extensions.md
+++ b/source/documentation/extending-sculpin/community-extensions.md
@@ -1,0 +1,75 @@
+---
+title: Community Extensions
+slug: extending-sculpin/community-extensions
+
+---
+
+Community-made extensions are a great way to extend the capabilities of
+your Sculpin site.
+
+<blockquote>
+Know of an extension that belongs on this list? Send a Pull
+Request to the <a href="https://github.com/sculpin/sculpin.io">
+sculpin.io</a> repository on GitHub, or reach out to <strong><a
+href="https://twitter.com/getsculpin">@getsculpin</a></strong> on
+Twitter!
+</blockquote>
+
+**[Meta Navigation Bundle](https://packagist.org/packages/janbuecker/sculpin-meta-navigation-bundle)**
+
+This extension helps you build navigation menus for your site.
+
+To make a menu item visible, add a `menu_title` entry to the page's
+front matter.
+
+Then, loop on `page.menu` to produce your menu, allowing up to
+3 levels of depth.
+
+**[Icelus Thumbnail Generator](https://packagist.org/packages/beryllium/icelus)**
+
+Generate thumbnails from within Twig:
+
+```
+{% verbatim %}
+<a href="image.jpg"><img src="{{ thumbnail('image.jpg', 100, 100) }}"></a>
+{% endverbatim %}
+```
+
+**[Related Posts Bundle](https://packagist.org/packages/tsphethean/sculpin-related-posts-bundle)**
+
+List five related posts (based on tag and category correlations) below
+any given post:
+
+```
+{% verbatim %}
+{% if page.related %}
+<ul>
+  {% for relate in page.related %}
+  <li><a href="{{ relate.source.url }}">{{ relate.title }}</a></li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endverbatim %}
+```
+
+**[Twig Markdown Bundle](https://packagist.org/packages/opdavies/sculpin-twig-markdown-bundle)**
+
+Process markdown strings from within Twig:
+
+```
+{% verbatim %}
+{{ some_content|markdown }}
+{% endverbatim %}
+```
+
+**[Sort By Field Bundle](https://packagist.org/packages/opdavies/sculpin-twig-sort-by-field-bundle)**
+
+From within Twig, allows you to sort arrays by key:
+
+```
+{% verbatim %}
+{% for i in myArray | sortbyfield('array_sort_key') %}
+  {{ i.array_sort_key }}
+{% endfor %}
+{% endverbatim %}
+```

--- a/source/documentation/extending-sculpin/creating-bundles.md
+++ b/source/documentation/extending-sculpin/creating-bundles.md
@@ -12,8 +12,11 @@ that hook into [Sculpin's event lifecycle][3].
 
 Register your own bundles as described in the [configuration][4] section.
 
+You may find it helpful to look at the existing [community extensions][5]
+for inspiration and examples.
 
 [1]: http://symfony.com/doc/current/cookbook/bundles/
 [2]: http://symfony.com/doc/current/cookbook/bundles/best_practices.html
 [3]: {{site.url}}/documentation/extending-sculpin/lifecycle/
 [4]: {{site.url}}/documentation/extending-sculpin/configuration/
+[5]: {{site.url}}/documentation/extending-sculpin/community-extensions/


### PR DESCRIPTION
I found every Sculpin-adjacent project on Packagist and examined each one to see which ones worked with Sculpin 3.

This PR includes the few that passed the test.

A number of extensions had stability mismatches, likely due to the period of great uncertainty in Sculpin 2. They might be able to work with minor tweaks.

Some other extensions would require more significant tweaks to get working in Sculpin 3, from interface mismatches to editing their service definitions.

A few extensions have been supplanted by the content:create command added in Sculpin 3.