### PR TITLE
Remove Pantheon Docs from powered-by-site list.

### DIFF
--- a/source/_views/includes/powered-by.html
+++ b/source/_views/includes/powered-by.html
@@ -76,11 +76,6 @@
     </li>
 
     <li class="powered-by-site">
-        <a class="title" href="https://pantheon.io/docs">Pantheon Documentation</a>
-        <a class="source" href="https://github.com/pantheon-systems/documentation"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
         <a class="title" href="https://securepasswords.info">SecurePasswords.info</a>
         <a class="source" href="https://github.com/dshafik/securepasswords.info"><i class="icon icon-github"></i></a>
     </li>


### PR DESCRIPTION
Pantheon now uses Gatsby to build our documentation.