### PR TITLE
Remove REFLX Labs and Palantir Holiday 2013 from Powered By section

### DIFF
--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -141,11 +141,6 @@ GitHub, or reach out to <strong><a href="https://twitter.com/getsculpin">@getscu
     </li>
 
     <li class="powered-by-site">
-        <a class="title" href="http://reflxlabsinc.com">REFLX Labs</a>
-        <a class="source" href="https://github.com/reflxlabs/reflxlabsinc.com"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
         <a class="title" href="http://yottaram.com">Yottaram</a>
         <a class="source" href="https://github.com/jonstavis/yottaram.com"><i class="icon icon-github"></i></a>
     </li>
@@ -200,11 +195,6 @@ GitHub, or reach out to <strong><a href="https://twitter.com/getsculpin">@getscu
     </li>
 
     <li class="powered-by-site">
-        <a class="title" href="https://pantheon.io/docs">Pantheon Documentation</a>
-        <a class="source" href="https://github.com/pantheon-systems/documentation"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
         <a class="title" href="https://securepasswords.info">SecurePasswords.info</a>
         <a class="source" href="https://github.com/dshafik/securepasswords.info"><i class="icon icon-github"></i></a>
     </li>
@@ -221,10 +211,6 @@ GitHub, or reach out to <strong><a href="https://twitter.com/getsculpin">@getscu
     <li class="powered-by-site">
         <a class="title" href="http://2013.notrollsallowed.com/">No Trolls Allowed</a>
         <a class="source" href="https://github.com/ntacamp/2013.notrollsallowed.com"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://holiday2013.palantir.net/">Palantir Holiday 2013</a>
     </li>
 
     <li class="powered-by-site">
@@ -319,7 +305,6 @@ GitHub, or reach out to <strong><a href="https://twitter.com/getsculpin">@getscu
     <li class="powered-by-site">
         <a class="title" href="https://skey.uk">Stefan Kecskes</a>
     </li>
-        
     </ul>
 
 </div>

--- a/docs/documentation/basic-project/index.html
+++ b/docs/documentation/basic-project/index.html
@@ -212,7 +212,7 @@ generating the site.</p>
 <h2 id="environments">Environments</h2>
 
 <p>Sculpin knows the <code>dev</code> and <code>prod</code> environment. They allow you to have
-<a href="configuration/">different configuration settings by environment</a>.</p>
+<a href="https://sculpin.io/documentation/sources/">different configuration settings by environment</a>.</p>
 
 <p>Sculpin assumes that all commands will be run in the <code>dev</code> environment
 unless otherwise specified.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -167,11 +167,6 @@
     </li>
 
     <li class="powered-by-site">
-        <a class="title" href="http://reflxlabsinc.com">REFLX Labs</a>
-        <a class="source" href="https://github.com/reflxlabs/reflxlabsinc.com"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
         <a class="title" href="http://yottaram.com">Yottaram</a>
         <a class="source" href="https://github.com/jonstavis/yottaram.com"><i class="icon icon-github"></i></a>
     </li>
@@ -226,11 +221,6 @@
     </li>
 
     <li class="powered-by-site">
-        <a class="title" href="https://pantheon.io/docs">Pantheon Documentation</a>
-        <a class="source" href="https://github.com/pantheon-systems/documentation"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
         <a class="title" href="https://securepasswords.info">SecurePasswords.info</a>
         <a class="source" href="https://github.com/dshafik/securepasswords.info"><i class="icon icon-github"></i></a>
     </li>
@@ -247,10 +237,6 @@
     <li class="powered-by-site">
         <a class="title" href="http://2013.notrollsallowed.com/">No Trolls Allowed</a>
         <a class="source" href="https://github.com/ntacamp/2013.notrollsallowed.com"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://holiday2013.palantir.net/">Palantir Holiday 2013</a>
     </li>
 
     <li class="powered-by-site">
@@ -340,6 +326,10 @@
 
     <li class="powered-by-site">
         <a class="title" href="http://games.anthony-dessalles.com/">Anthony Dessalles' Games</a>
+    </li>
+        
+    <li class="powered-by-site">
+        <a class="title" href="https://skey.uk">Stefan Kecskes</a>
     </li>
     </ul>
 

--- a/source/_views/includes/powered-by.html
+++ b/source/_views/includes/powered-by.html
@@ -17,11 +17,6 @@
     </li>
 
     <li class="powered-by-site">
-        <a class="title" href="http://reflxlabsinc.com">REFLX Labs</a>
-        <a class="source" href="https://github.com/reflxlabs/reflxlabsinc.com"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
         <a class="title" href="http://yottaram.com">Yottaram</a>
         <a class="source" href="https://github.com/jonstavis/yottaram.com"><i class="icon icon-github"></i></a>
     </li>
@@ -92,10 +87,6 @@
     <li class="powered-by-site">
         <a class="title" href="http://2013.notrollsallowed.com/">No Trolls Allowed</a>
         <a class="source" href="https://github.com/ntacamp/2013.notrollsallowed.com"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://holiday2013.palantir.net/">Palantir Holiday 2013</a>
     </li>
 
     <li class="powered-by-site">

--- a/source/documentation/basic-project.md
+++ b/source/documentation/basic-project.md
@@ -92,7 +92,7 @@ With this option passed, `{{ site.url }}/about` will now be generated as
 ## Environments
 
 Sculpin knows the `dev` and `prod` environment. They allow you to have
-[different configuration settings by environment](configuration/).
+[different configuration settings by environment]({{site.url}}/documentation/sources/).
 
 Sculpin assumes that all commands will be run in the `dev` environment
 unless otherwise specified.


### PR DESCRIPTION
REFLX Labs redirects to http://www.jby49.cn/ (site is in Chinese)
Palantir Holiday 2013 returns 404 (There isn't a GitHub Pages site here)