### PR TITLE
fix(html): remove historic `shortcut` attribute for icon

### DIFF
--- a/source/_views/base.twig
+++ b/source/_views/base.twig
@@ -22,14 +22,14 @@
     <link rel="apple-touch-startup-image" href="/images/jackson/2048x2048.png">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <link rel="shortcut icon" sizes="76x76" href="/images/jackson/76x76.png">
-    <link rel="shortcut icon" sizes="120x120" href="/images/jackson/120x120.png">
-    <link rel="shortcut icon" sizes="128x128" href="/images/jackson/128x128.png">
-    <link rel="shortcut icon" sizes="152x152" href="/images/jackson/152x152.png">
-    <link rel="shortcut icon" sizes="196x196" href="/images/jackson/196x196.png">
-    <link rel="shortcut icon" sizes="512x512" href="/images/jackson/512x512.png">
-    <link rel="shortcut icon" sizes="1024x1024" href="/images/jackson/1024x1024.png">
-    <link rel="shortcut icon" sizes="2048x2048" href="/images/jackson/2048x2048.png">
+    <link rel="icon" sizes="76x76" href="/images/jackson/76x76.png">
+    <link rel="icon" sizes="120x120" href="/images/jackson/120x120.png">
+    <link rel="icon" sizes="128x128" href="/images/jackson/128x128.png">
+    <link rel="icon" sizes="152x152" href="/images/jackson/152x152.png">
+    <link rel="icon" sizes="196x196" href="/images/jackson/196x196.png">
+    <link rel="icon" sizes="512x512" href="/images/jackson/512x512.png">
+    <link rel="icon" sizes="1024x1024" href="/images/jackson/1024x1024.png">
+    <link rel="icon" sizes="2048x2048" href="/images/jackson/2048x2048.png">
     <link rel="apple-touch-icon" sizes="76x76" href="/images/jackson/76x76.png">
     <link rel="apple-touch-icon" sizes="120x120" href="/images/jackson/120x120.png">
     <link rel="apple-touch-icon" sizes="128x128" href="/images/jackson/128x128.png">


### PR DESCRIPTION
This attribute is useless and not required.

Reference:
https://html.spec.whatwg.org/multipage/links.html#rel-icon
