### PR TITLE
Add `generator` metatag

### DIFF
--- a/source/_views/base.twig
+++ b/source/_views/base.twig
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     {% if page.full_title %}


### PR DESCRIPTION
Add a `generator` metatag that shows the site is generated using Sculpin and links to https://sculpin.io.