### PR TITLE
Move "Powered By" data to site settings and simplify template

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -83,3 +83,91 @@ docs:
                 name: Lifecycle
                 url: documentation/extending-sculpin/lifecycle/
                 slug: extending-sculpin/lifecycle
+powered_by:
+    -
+        category: Company Sites
+        sites:
+            -
+                name: Yottaram
+                url: http://yottaram.com
+                repo_url: https://github.com/jonstavis/yottaram.com
+            -
+                name: Future500 B.V.
+                url: http://future500.nl
+            -
+                name: Geocod.io
+                url: https://geocod.io
+            -
+                name: ifdattic.com
+                url: http://www.ifdattic.com
+            -
+                name: Audiodog
+                url: http://www.audiodog.co.uk
+    -
+        category: Open Source Sites/Documentation
+        sites:
+            -
+                name: The PHP Foundation
+                url: https://thephp.foundation
+                repo_url: https://github.com/ThePHPF/thephp.foundation
+            -
+                name: Sculpin
+                url: https://sculpin.io
+                repo_url: https://github.com/sculpin/sculpin.io
+            -
+                name: Stack
+                url: http://stackphp.com
+                repo_url: https://github.com/stackphp/stackphp.com
+            -
+                name: sabre/dav
+                url: http://sabre.io
+                repo_url: https://github.com/fruux/sabre.io
+            -
+                name: Phergie.org
+                url: http://phergie.org
+                repo_url: https://github.com/phergie/phergie.org
+    -
+        category: Community Sites
+        sites:
+            -
+                name: labs @ Qandidate.com
+                url: http://labs.qandidate.com
+            -
+                name: Memphis Technology Foundation
+                url: http://www.memphistechnology.org
+                repo_url: https://github.com/memtech/memphistechnology.org
+            -
+                name: Sheffield PHP User Group
+                url: https://shefphp.github.io
+                repo_url: https://github.com/ShefPHP/ShefPHP.github.io
+    -
+        category: Blogs/Personal Sites
+        sites:
+            -
+                name: whateverthing.com
+                url: http://whateverthing.com
+            -
+                name: asm89
+                url: http://asm89.github.io
+            -
+                name: Cees-Jan Kiewiet's blog
+                url: https://blog.wyrihaximus.net
+                repo_url: https://github.com/WyriHaximus/blog.wyrihaximus.net
+            -
+                name: Oliver Davies
+                url: https://www.oliverdavies.uk
+                repo_url: https://git.oliverdavies.uk/opdavies/oliverdavies.uk
+            -
+                name: Ben Plummer
+                url: https://benplummer.uk
+                repo_url: https://github.com/benplummer/website
+            -
+                name: CoderSpirit.XYZ
+                url: http://blog.coderspirit.xyz
+                repo_url: https://github.com/castarco/coderspirit.blog
+            -
+                name: Stefan Kecskes
+                url: https://skey.uk
+            -
+                name: Sailing Co-Ops
+                url: https://www.sailingcoops.com

--- a/source/_views/includes/powered-by.html
+++ b/source/_views/includes/powered-by.html
@@ -1,111 +1,17 @@
 <div class="powered-by">
-    <h3>Company Sites</h3>
+    {% for section in site.powered_by %}
+        <h3>{{ section.category }}</h3>
 
-    <ul class="list-inline">
-    <li class="powered-by-site">
-        <a class="title" href="http://yottaram.com">Yottaram</a>
-        <a class="source" href="https://github.com/jonstavis/yottaram.com"><i class="icon icon-github"></i></a>
-    </li>
+        <ul class="list-inline">
+            {% for item in section.sites %}
+                <li class="powered-by-site">
+                    <a class="title" href="{{ item.url }}">{{ item.name }}</a>
 
-    <li class="powered-by-site">
-        <a class="title" href="http://future500.nl">Future500 B.V.</a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="https://geocod.io">Geocod.io</a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://www.ifdattic.com/">ifdattic.com</a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://www.audiodog.co.uk">Audiodog</a>
-    </li>
-    </ul>
-
-    <h3>Open Source Sites/Documentation</h3>
-
-    <ul class="list-inline">
-    <li class="powered-by-site">
-        <a class="title" href="https://thephp.foundation/">The PHP Foundation</a>
-        <a class="source" href="https://github.com/ThePHPF/thephp.foundation"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="https://sculpin.io/">Sculpin</a>
-        <a class="source" href="https://github.com/sculpin/sculpin.io"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://stackphp.com/">Stack</a>
-        <a class="source" href="https://github.com/stackphp/stackphp.com"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://sabre.io/">sabre/dav</a>
-        <a class="source" href="https://github.com/fruux/sabre.io"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://phergie.org/">Phergie.org</a>
-        <a class="source" href="https://github.com/phergie/phergie.org/"><i class="icon icon-github"></i></a>
-    </li>
-    </ul>
-
-    <h3>Community Sites</h3>
-
-    <ul class="list-inline">
-
-    <li class="powered-by-site">
-        <a class="title" href="http://labs.qandidate.com/">labs @ Qandidate.com</a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://www.memphistechnology.org">Memphis Technology Foundation</a>
-        <a class="source" href="https://github.com/memtech/memphistechnology.org"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="https://shefphp.github.io">Sheffield PHP User Group</a>
-        <a class="source" href="https://github.com/ShefPHP/ShefPHP.github.io"><i class="icon icon-github"></i></a>
-    </li>
-
-    </ul>
-
-    <h3>Blogs/Personal Sites</h3>
-
-    <ul class="list-inline">
-    <li class="powered-by-site">
-        <a class="title" href="http://whateverthing.com/">whateverthing.com</a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://asm89.github.io/">asm89</a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="https://blog.wyrihaximus.net/">Cees-Jan Kiewiet's blog</a>
-        <a class="source" href="https://github.com/WyriHaximus/blog.wyrihaximus.net"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="https://benplummer.uk">Ben Plummer</a>
-        <a class="source" href="https://github.com/benplummer/website"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="http://blog.coderspirit.xyz">CoderSpirit.XYZ</a>
-        <a class="source" href="https://github.com/castarco/coderspirit.blog"><i class="icon icon-github"></i></a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="https://skey.uk">Stefan Kecskes</a>
-    </li>
-
-    <li class="powered-by-site">
-        <a class="title" href="https://www.sailingcoops.com/">Sailing Co-Ops</a>
-    </li>
-    </ul>
-
+                    {% if item.repo_url -%}
+                        <a class="source" href="{{ item.repo_url }}"><i class="icon icon-github"></i></a>
+                    {%- endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    {% endfor %}
 </div>


### PR DESCRIPTION
As discussed in yesterday's pair programming session and in #140, this PR makes the "Powered By" component more scalable and easier to add more examples without changing the HTML markup by moving the categories and site data to sculpin_site.yml.

To match the existing functionality, only the website name and URL are added if no `repo_url` is entered, so no GitHub icon is added. 

The downside to this is this file is cached by the local Sculpin server, so if changes are made whilst running `sculpin generate --watch`, the changes won't be visible until the server is restarted.

I've also re-added my website that was accidentally removed in the previous commit.