### PR TITLE
Add sculpin bundles section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,38 @@ It's not mandatory to follow this recommendation, but it does help make
 it easier on maintainers. They'll be able to click the "Merge" button
 and the changes will be deployed immediately.
 
+Bundles
+-------
+
+The Bundles list on the home page and the community page is rendered
+from `app/config/bundles.yml`.
+
+`scripts/fetch-bundles.php` discovers bundles on GitHub and refreshes
+their metadata from GitHub and Packagist:
+
+    GITHUB_TOKEN=... composer fetch-bundles
+
+A repository is discovered if it has the `sculpin-bundle` topic, or if
+its name contains both "sculpin" and "bundle". The token is optional,
+but without one the GitHub Search API allows only 10 requests per
+minute.
+
+The script never publishes anything on its own. New finds are written to
+the `discovered` list, which is not rendered; a maintainer moves the
+entries that belong on the site into `bundles`, and adds anything that
+should never be listed to `ignored`.
+
+To add a bundle by hand, add an entry to `bundles` with a `name`,
+`repository` and `description`, then run the script to fill in the rest.
+It refreshes `description`, `version`, `updated`, `stars`, `archived`
+and `abandoned` on every run, keeps both lists in alphabetical order, and
+leaves everything else alone.
+
+What gets rendered is decided in
+`source/_views/includes/bundles.html`, not by the file order: bundles
+marked abandoned on Packagist are skipped, and the rest are listed most
+recently updated first.
+
 Notes
 -----
 

--- a/app/config/bundles.yml
+++ b/app/config/bundles.yml
@@ -1,0 +1,384 @@
+# Sculpin bundles listed on sculpin.io.
+#
+# `bundles` is rendered on the home page and the community page. `discovered`
+# holds repositories found by scripts/fetch-bundles.php that a maintainer has
+# not reviewed yet, and is never rendered. `ignored` repositories are skipped
+# by discovery entirely.
+#
+# To add a bundle by hand, add an entry to `bundles` with at least `name`,
+# `repository` and `description`, then run:
+#
+#     composer fetch-bundles
+#
+# That run fills in the rest. It refreshes description, version, updated,
+# stars, archived and abandoned on every run; `name` and any other keys you add
+# are left alone.
+#
+# Both lists are kept in alphabetical order here. The site renders `bundles`
+# most recently updated first, and skips anything marked abandoned; see
+# source/_views/includes/bundles.html.
+
+bundles:
+    -
+        name: 'Icelus Thumbnail Generator'
+        package: beryllium/icelus
+        repository: 'https://github.com/beryllium/icelus'
+        description: 'Generate image thumbnails from within Twig.'
+        version: 2.2.0
+        updated: '2026-07-07'
+        stars: 10
+        archived: false
+        abandoned: false
+    -
+        name: 'Meta Navigation Bundle'
+        package: janbuecker/sculpin-meta-navigation-bundle
+        repository: 'https://github.com/janbuecker/sculpin-meta-navigation-bundle'
+        description: 'Build navigation menus from page front matter, with up to three levels of depth.'
+        version: v0.9
+        updated: '2022-08-26'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Related Posts Bundle'
+        package: tsphethean/sculpin-related-posts-bundle
+        repository: 'https://github.com/tsphethean/sculpin-related-posts-bundle'
+        description: 'List related posts based on tag and category correlations.'
+        version: 0.1.0
+        updated: '2015-07-22'
+        stars: 5
+        archived: false
+        abandoned: false
+    -
+        name: 'Sort By Field Bundle'
+        package: opdavies/sculpin-twig-sort-by-field-bundle
+        repository: 'https://github.com/opdavies/sculpin-twig-sort-by-field-bundle'
+        description: 'Sort arrays by key from within Twig.'
+        version: 1.0.0
+        updated: '2017-03-05'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Twig Markdown Bundle'
+        package: opdavies/sculpin-twig-markdown-bundle
+        repository: 'https://github.com/opdavies/sculpin-twig-markdown-bundle'
+        description: 'Render Markdown strings from within Twig.'
+        version: 0.2.0
+        updated: '2019-12-28'
+        stars: 0
+        archived: false
+        abandoned: false
+discovered:
+    -
+        name: 'Ab Test Bundle'
+        package: yaenergetik/sculpin-ab-test-bundle
+        repository: 'https://github.com/Andrey96/sculpin-ab-test-bundle'
+        description: 'ABTest Bundle for Sculpin'
+        version: null
+        updated: '2016-08-18'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Ab Test Bundle'
+        package: yaenergetik/sculpin-ab-test-bundle
+        repository: 'https://github.com/ertrade/sculpin-ab-test-bundle'
+        description: 'ABTest Bundle for Sculpin'
+        version: null
+        updated: '2016-08-19'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Algolia Search Bundle'
+        package: timbroder/sculpin-algolia
+        repository: 'https://github.com/timbroder/SculpinAlgoliaSearchBundle'
+        description: 'Provides search in static site via Algolia https://www.algolia.com'
+        version: null
+        updated: '2016-01-05'
+        stars: 2
+        archived: false
+        abandoned: false
+    -
+        name: 'Calendarian Bundle'
+        package: sharkpp/sculpin-calendarian-bundle
+        repository: 'https://github.com/sharkpp/sculpin-calendarian-bundle'
+        description: 'This is a Bundle that generates the index page to blog date directory for Sculpin.'
+        version: null
+        updated: '2016-09-03'
+        stars: 1
+        archived: false
+        abandoned: false
+    -
+        name: 'Commonmark Bundle'
+        package: bcremer/sculpin-commonmark-bundle
+        repository: 'https://github.com/bcremer/sculpin-commonmark-bundle'
+        description: 'Sculpin league/commonmark bundle'
+        version: 0.5.0
+        updated: '2021-11-08'
+        stars: 3
+        archived: false
+        abandoned: false
+    -
+        name: 'Content Generator Bundle'
+        package: opdavies/sculpin-content-generator-bundle
+        repository: 'https://github.com/opdavies/sculpin-content-generator-bundle'
+        description: null
+        version: 1.1.1
+        updated: '2018-02-18'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Contentful Bundle'
+        package: airtonzanon/sculpin-contentful-bundle
+        repository: 'https://github.com/airtonzanon/sculpin-contentful-bundle'
+        description: 'Fetch contentful content and dump the markdowns as posts for sculpin'
+        version: 0.0.10
+        updated: '2024-02-27'
+        stars: 1
+        archived: false
+        abandoned: false
+    -
+        name: 'Date Navigation Bundle'
+        package: jbouzekri/sculpin-date-navigation-bundle
+        repository: 'https://github.com/jbouzekri/SculpinDateNavigationBundle'
+        description: 'Generate date navigation block (with pages) in Sculpin'
+        version: 1.0.0
+        updated: '2014-07-21'
+        stars: 1
+        archived: false
+        abandoned: false
+    -
+        name: 'Dflydev Twig GitHub Gist Bundle'
+        package: dflydev/twig-github-gist-sculpin-bundle
+        repository: 'https://github.com/dflydev/dflydev-twig-gitHub-gist-sculpin-bundle'
+        description: 'Twig GitHub Gist Sculpin Bundle'
+        version: null
+        updated: '2012-08-15'
+        stars: 2
+        archived: false
+        abandoned: false
+    -
+        name: 'Editor Bundle'
+        package: mavimo/sculpin-editor-bundle
+        repository: 'https://github.com/mavimo/sculpin-editor-bundle'
+        description: 'Sculpin Editor Bundle'
+        version: null
+        updated: '2017-05-23'
+        stars: 5
+        archived: false
+        abandoned: false
+    -
+        name: 'Facebook Importer Bundle'
+        package: technikh/sculpin-fb-bundle
+        repository: 'https://github.com/TechNikh/Sculpin-Facebook-Importer-Bundle'
+        description: null
+        version: null
+        updated: '2022-05-20'
+        stars: 1
+        archived: false
+        abandoned: false
+    -
+        name: 'Fillet Bundle'
+        package: dragonmantank/fillet-sculpin-bundle
+        repository: 'https://github.com/dragonmantank/fillet-sculpin-bundle'
+        description: 'Bundle wrapper for Fillet'
+        version: v0.1.0
+        updated: '2015-09-01'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Gist Embed Bundle'
+        package: opdavies/sculpin-gist-embed-bundle
+        repository: 'https://github.com/opdavies/sculpin-gist-embed-bundle'
+        description: 'Allows for embedding GitHub Gists into a Sculpin site.'
+        version: 0.1.0
+        updated: '2018-02-18'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Gulp Bundle'
+        package: petemc/sculpin-gulp-bundle
+        repository: 'https://github.com/petemcfarlane/sculpin-gulp-bundle'
+        description: 'Runs a gulp task called `sculpin` from your `gulpfile.js` after running the `sculpin generate` command.'
+        version: v0.0.1
+        updated: '2016-04-13'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Latest Posts Bundle'
+        package: null
+        repository: 'https://github.com/opdavies/sculpin-latest-posts-bundle'
+        description: 'A custom bundle for displaying the latest posts on a Sculpin site.'
+        version: null
+        updated: '2015-08-08'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Less Bundle'
+        package: bcremer/sculpin-less-bundle
+        repository: 'https://github.com/bcremer/sculpin-less-bundle'
+        description: 'Sculpin LESS bundle'
+        version: 0.3.0
+        updated: '2023-01-09'
+        stars: 6
+        archived: false
+        abandoned: false
+    -
+        name: 'Lists Bundle'
+        package: delssajri/sculpin-lists-bundle
+        repository: 'https://github.com/delssajri/sculpin-lists-bundle'
+        description: null
+        version: null
+        updated: '2016-03-14'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Mt Haml Bundle'
+        package: fervo/sculpin-mthaml-bundle
+        repository: 'https://github.com/fervo/SculpinMtHamlBundle'
+        description: 'MtHaml Bundle for Sculpin'
+        version: null
+        updated: '2016-01-12'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'OEmbed Bundle'
+        package: bangpound/sculpin-oembed-bundle
+        repository: 'https://github.com/bangpound/Sculpin-oEmbed-Bundle'
+        description: 'oEmbed bundle for Sculpin static site generator'
+        version: null
+        updated: '2015-07-11'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Pages Bundle'
+        package: fab/sculpin-pages-bundle
+        repository: 'https://github.com/fabarea/sculpin-pages-bundle'
+        description: 'Sculpin Pages Bundle'
+        version: 1.0.0
+        updated: '2015-03-03'
+        stars: 5
+        archived: false
+        abandoned: false
+    -
+        name: 'Press Bundle'
+        package: null
+        repository: 'https://github.com/simensen/press-sculpin-bundle'
+        description: '[WIP] Quick example of building a Sculpin bundle to add another type of content'
+        version: null
+        updated: '2013-12-26'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Projects Bundle'
+        package: mavimo/sculpin-projects-bundle
+        repository: 'https://github.com/mavimo/sculpin-projects-bundle'
+        description: 'Sculpin Projects Bundle'
+        version: null
+        updated: '2014-01-02'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Redirect Bundle'
+        package: mavimo/sculpin-redirect-bundle
+        repository: 'https://github.com/mavimo/sculpin-redirect-bundle'
+        description: 'Sculpin Redirect Bundle'
+        version: null
+        updated: '2015-07-26'
+        stars: 6
+        archived: false
+        abandoned: false
+    -
+        name: 'Related Content Bundle'
+        package: wjzijderveld/sculpin-related-content-bundle
+        repository: 'https://github.com/wjzijderveld/SculpinRelatedContentBundle'
+        description: 'Sculpin Bundle to generate related content data'
+        version: 1.0.1
+        updated: '2014-07-31'
+        stars: 4
+        archived: true
+        abandoned: true
+    -
+        name: 'Scss Bundle'
+        package: devworks/sculpin-scss-bundle
+        repository: 'https://github.com/devworks/sculpin-scss-bundle'
+        description: 'Sculpin SCSS Bundle'
+        version: '0.1'
+        updated: '2019-02-20'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Search Bundle'
+        package: jbouzekri/sculpin-search-bundle
+        repository: 'https://github.com/jbouzekri/SculpinSearchBundle'
+        description: 'Provides search in static site via indextank search engine'
+        version: 1.0.1
+        updated: '2014-07-21'
+        stars: 1
+        archived: false
+        abandoned: false
+    -
+        name: 'Show Layout Bundle'
+        package: dupuchba/sculpin-show-layout-bundle
+        repository: 'https://github.com/dupuchba/sculpin-show-layout-bundle'
+        description: '[WIP] Sculpin bundle that attempt to display original layout to the user'
+        version: null
+        updated: '2015-03-25'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Sitemap Bundle'
+        package: nickpeirson/sculpin-sitemap-bundle
+        repository: 'https://github.com/nickpeirson/sculpin-sitemap-bundle'
+        description: null
+        version: 0.1.1
+        updated: '2020-08-18'
+        stars: 3
+        archived: false
+        abandoned: false
+    -
+        name: 'Tag Cloud Bundle'
+        package: jbouzekri/sculpin-tag-cloud-bundle
+        repository: 'https://github.com/jbouzekri/SculpinTagCloudBundle'
+        description: 'Generate a tag cloud in sculpin'
+        version: '1.2'
+        updated: '2015-07-12'
+        stars: 2
+        archived: false
+        abandoned: false
+    -
+        name: 'Twig Markdown Bundle'
+        package: opdavies/sculpin-twig-markdown-bundle
+        repository: 'https://github.com/emrysal/sculpin-twig-markdown-bundle'
+        description: null
+        version: 0.2.0
+        updated: '2021-05-06'
+        stars: 0
+        archived: false
+        abandoned: false
+    -
+        name: 'Webpack Encore Bundle'
+        package: niels-nijens/sculpin-webpack-encore-bundle
+        repository: 'https://github.com/jacktonkin/sculpin-webpack-encore-bundle'
+        description: 'Sculpin integration with Webpack Encore!'
+        version: null
+        updated: '2023-12-05'
+        stars: 0
+        archived: false
+        abandoned: false
+ignored:
+    - 'https://github.com/sculpin/posts-bundle'

--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -1,3 +1,6 @@
+imports:
+    - bundles.yml
+
 title: Sculpin
 subtitle: PHP Static Site Generator
 assets_version: 6

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,9 @@
         }
     },
     "scripts": {
+        "fetch-bundles": [
+            "@php scripts/fetch-bundles.php"
+        ],
         "watch": [
             "Composer\\Config::disableProcessTimeout",
             "vendor/bin/sculpin generate --watch --server"

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Community &mdash; Sculpin &mdash; PHP Static Site Generator</title>
@@ -229,6 +230,91 @@ GitHub, or reach out to <strong><a href="https://phpc.social/@sculpin">@sculpin@
                                     </li>
                     </ul>
     </div>
+</p>
+
+<hr>
+
+<h2 id="bundles">Bundles</h2>
+
+<p>Bundles extend Sculpin with extra functionality. Have one you'd like listed
+here? Add the <code>sculpin-bundle</code> topic to your repository on GitHub, or
+send a Pull Request to the <a href="https://github.com/sculpin/sculpin.io">sculpin.io</a>
+repository.</p>
+
+<p><div class="bundles">
+    <ul class="list-inline">
+                    <li class="bundle">
+                <a class="title" href="https://github.com/beryllium/icelus">Icelus Thumbnail Generator</a>
+
+                <a class="source" href="https://github.com/beryllium/icelus"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                                    <p class="description">Generate image thumbnails from within Twig.</p>
+                
+                <p class="meta">
+                                            <span class="version">2.2.0</span>
+                    
+                                            <span class="updated">Updated Jul 2026</span>
+                    
+                                    </p>
+            </li>
+                    <li class="bundle">
+                <a class="title" href="https://github.com/janbuecker/sculpin-meta-navigation-bundle">Meta Navigation Bundle</a>
+
+                <a class="source" href="https://github.com/janbuecker/sculpin-meta-navigation-bundle"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                                    <p class="description">Build navigation menus from page front matter, with up to three levels of depth.</p>
+                
+                <p class="meta">
+                                            <span class="version">v0.9</span>
+                    
+                                            <span class="updated">Updated Aug 2022</span>
+                    
+                                    </p>
+            </li>
+                    <li class="bundle">
+                <a class="title" href="https://github.com/opdavies/sculpin-twig-markdown-bundle">Twig Markdown Bundle</a>
+
+                <a class="source" href="https://github.com/opdavies/sculpin-twig-markdown-bundle"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                                    <p class="description">Render Markdown strings from within Twig.</p>
+                
+                <p class="meta">
+                                            <span class="version">0.2.0</span>
+                    
+                                            <span class="updated">Updated Dec 2019</span>
+                    
+                                    </p>
+            </li>
+                    <li class="bundle">
+                <a class="title" href="https://github.com/opdavies/sculpin-twig-sort-by-field-bundle">Sort By Field Bundle</a>
+
+                <a class="source" href="https://github.com/opdavies/sculpin-twig-sort-by-field-bundle"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                                    <p class="description">Sort arrays by key from within Twig.</p>
+                
+                <p class="meta">
+                                            <span class="version">1.0.0</span>
+                    
+                                            <span class="updated">Updated Mar 2017</span>
+                    
+                                    </p>
+            </li>
+                    <li class="bundle">
+                <a class="title" href="https://github.com/tsphethean/sculpin-related-posts-bundle">Related Posts Bundle</a>
+
+                <a class="source" href="https://github.com/tsphethean/sculpin-related-posts-bundle"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                                    <p class="description">List related posts based on tag and category correlations.</p>
+                
+                <p class="meta">
+                                            <span class="version">0.1.0</span>
+                    
+                                            <span class="updated">Updated Jul 2015</span>
+                    
+                                    </p>
+            </li>
+            </ul>
+</div>
 </p>
                     </div>
     </section>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -269,6 +269,52 @@ footer.site .copyright {
 	color: #DFE7EA;
 }
 
+.bundles ul.list-inline {
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-gap: 2vw;
+}
+
+.bundles ul li a {
+	text-decoration: none;
+}
+
+.bundles li.bundle {
+	padding: .5em;
+	text-align: left;
+}
+
+.bundles .bundle .title {
+	font-size: 1.2em;
+}
+
+.bundles .bundle .source {
+	color: #C0CFD5;
+	font-size: .75em;
+}
+.bundles .bundle .source:hover {
+	color: #DFE7EA;
+}
+
+.bundles .bundle .description,
+.bundles .bundle .meta {
+	font-size: .8em;
+	margin: .5em 0 0;
+}
+
+.bundles .bundle .meta {
+	color: #C0CFD5;
+}
+
+.bundles .bundle .meta span + span:before {
+	content: "\00b7  ";
+}
+
+.bundles .bundle .meta .flag {
+	color: #C1543F;
+	text-transform: uppercase;
+}
+
 
 section.content {
 	color: #547989;
@@ -610,6 +656,10 @@ only screen and (                min-resolution: 2dppx)  and (min-width: 600px) 
 @media only screen and (min-width: 768px) {
 	.powered-by .powered-by-site .source {
 		font-size: .5em;
+	}
+
+	.bundles ul.list-inline {
+		grid-template-columns: repeat(2, 1fr);
 	}
 }
 

--- a/docs/documentation/additional-skeletons/index.html
+++ b/docs/documentation/additional-skeletons/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Additional Skeletons &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/basic-project/index.html
+++ b/docs/documentation/basic-project/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Basic Project &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/bundles/SculpinPostsBundle/index.html
+++ b/docs/documentation/bundles/SculpinPostsBundle/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>SculpinPostsBundle &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/configuration/index.html
+++ b/docs/documentation/configuration/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Configuration &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/content-types/custom-types/index.html
+++ b/docs/documentation/content-types/custom-types/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Custom Types &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/content-types/index.html
+++ b/docs/documentation/content-types/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Content Types &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/content-types/posts/index.html
+++ b/docs/documentation/content-types/posts/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Posts &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/converters/index.html
+++ b/docs/documentation/converters/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Converters &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/extending-sculpin/community-extensions/index.html
+++ b/docs/documentation/extending-sculpin/community-extensions/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Community Extensions &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/extending-sculpin/configuration/index.html
+++ b/docs/documentation/extending-sculpin/configuration/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Configuration &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/extending-sculpin/creating-bundles/index.html
+++ b/docs/documentation/extending-sculpin/creating-bundles/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Creating Bundles &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/extending-sculpin/index.html
+++ b/docs/documentation/extending-sculpin/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Extending Sculpin &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/extending-sculpin/lifecycle/index.html
+++ b/docs/documentation/extending-sculpin/lifecycle/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Sculpin Lifecycle &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/formatters/index.html
+++ b/docs/documentation/formatters/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Formatters &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/generators/index.html
+++ b/docs/documentation/generators/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Generators &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Documentation &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/internals/index.html
+++ b/docs/documentation/internals/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Internals &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/layouts/index.html
+++ b/docs/documentation/layouts/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Layouts &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/sources/index.html
+++ b/docs/documentation/sources/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Sources &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/documentation/themes/index.html
+++ b/docs/documentation/themes/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Themes &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/download/index.html
+++ b/docs/download/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Download &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/getstarted/index.html
+++ b/docs/getstarted/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Get Started &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Sculpin &mdash; PHP Static Site Generator</title>
@@ -270,6 +271,87 @@
                                     </li>
                     </ul>
     </div>
+
+  <hr>
+
+  <h1>Bundles</h1>
+  <p>
+    Bundles extend Sculpin with extra functionality. Have one you'd like listed here? Add the <code>sculpin-bundle</code> topic to your repository on GitHub, or send a Pull Request to the <a href="https://github.com/sculpin/sculpin.io">sculpin.io</a> repository.
+  </p>
+  <div class="bundles">
+    <ul class="list-inline">
+                    <li class="bundle">
+                <a class="title" href="https://github.com/beryllium/icelus">Icelus Thumbnail Generator</a>
+
+                <a class="source" href="https://github.com/beryllium/icelus"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                                    <p class="description">Generate image thumbnails from within Twig.</p>
+                
+                <p class="meta">
+                                            <span class="version">2.2.0</span>
+                    
+                                            <span class="updated">Updated Jul 2026</span>
+                    
+                                    </p>
+            </li>
+                    <li class="bundle">
+                <a class="title" href="https://github.com/janbuecker/sculpin-meta-navigation-bundle">Meta Navigation Bundle</a>
+
+                <a class="source" href="https://github.com/janbuecker/sculpin-meta-navigation-bundle"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                                    <p class="description">Build navigation menus from page front matter, with up to three levels of depth.</p>
+                
+                <p class="meta">
+                                            <span class="version">v0.9</span>
+                    
+                                            <span class="updated">Updated Aug 2022</span>
+                    
+                                    </p>
+            </li>
+                    <li class="bundle">
+                <a class="title" href="https://github.com/opdavies/sculpin-twig-markdown-bundle">Twig Markdown Bundle</a>
+
+                <a class="source" href="https://github.com/opdavies/sculpin-twig-markdown-bundle"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                                    <p class="description">Render Markdown strings from within Twig.</p>
+                
+                <p class="meta">
+                                            <span class="version">0.2.0</span>
+                    
+                                            <span class="updated">Updated Dec 2019</span>
+                    
+                                    </p>
+            </li>
+                    <li class="bundle">
+                <a class="title" href="https://github.com/opdavies/sculpin-twig-sort-by-field-bundle">Sort By Field Bundle</a>
+
+                <a class="source" href="https://github.com/opdavies/sculpin-twig-sort-by-field-bundle"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                                    <p class="description">Sort arrays by key from within Twig.</p>
+                
+                <p class="meta">
+                                            <span class="version">1.0.0</span>
+                    
+                                            <span class="updated">Updated Mar 2017</span>
+                    
+                                    </p>
+            </li>
+                    <li class="bundle">
+                <a class="title" href="https://github.com/tsphethean/sculpin-related-posts-bundle">Related Posts Bundle</a>
+
+                <a class="source" href="https://github.com/tsphethean/sculpin-related-posts-bundle"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                                    <p class="description">List related posts based on tag and category correlations.</p>
+                
+                <p class="meta">
+                                            <span class="version">0.1.0</span>
+                    
+                                            <span class="updated">Updated Jul 2015</span>
+                    
+                                    </p>
+            </li>
+            </ul>
+</div>
 
 </div>
                     </div>

--- a/docs/mascot/index.html
+++ b/docs/mascot/index.html
@@ -5,6 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
     <meta charset="utf-8">
+    <meta name="generator" content="Sculpin (https://sculpin.io)" />
     <meta name="theme-color" content="#5b7c89">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>Jackson, the Sculpin mascot &mdash; Sculpin &mdash; PHP Static Site Generator</title>

--- a/scripts/fetch-bundles.php
+++ b/scripts/fetch-bundles.php
@@ -1,0 +1,428 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Discovers Sculpin bundles on GitHub and refreshes their metadata in
+ * app/config/bundles.yml.
+ *
+ * Newly discovered repositories are written to the `discovered` list, which is
+ * NOT rendered on the site. A maintainer reviews them and moves the ones that
+ * belong on sculpin.io into the `bundles` list.
+ *
+ * Usage:
+ *
+ *     php scripts/fetch-bundles.php
+ *     php scripts/fetch-bundles.php --dry-run
+ *
+ * A GitHub token is optional but strongly recommended; without one the Search
+ * API is limited to 10 requests per minute.
+ *
+ *     GITHUB_TOKEN=ghp_... php scripts/fetch-bundles.php
+ */
+
+use Symfony\Component\Yaml\Yaml;
+
+require __DIR__.'/../vendor/autoload.php';
+
+const CONFIG_FILE = __DIR__.'/../app/config/bundles.yml';
+
+const USER_AGENT = 'sculpin.io-bundle-fetcher';
+
+/**
+ * Repositories are discovered if they carry this GitHub topic, or if their name
+ * matches every one of NAME_PATTERNS.
+ */
+const TOPIC = 'sculpin-bundle';
+
+const SEARCH_QUERIES = [
+    'sculpin bundle in:name',
+    'topic:sculpin-bundle',
+];
+
+const NAME_PATTERNS = ['/sculpin/i', '/bundle/i'];
+
+/**
+ * Fields owned by the script. Everything else in an existing entry is left
+ * alone, so maintainers can edit `name` and `description` without the next run
+ * clobbering them.
+ */
+const MANAGED_FIELDS = ['description', 'version', 'updated', 'stars', 'archived', 'abandoned'];
+
+const FILE_HEADER = <<<'YAML'
+# Sculpin bundles listed on sculpin.io.
+#
+# `bundles` is rendered on the home page and the community page. `discovered`
+# holds repositories found by scripts/fetch-bundles.php that a maintainer has
+# not reviewed yet, and is never rendered. `ignored` repositories are skipped
+# by discovery entirely.
+#
+# To add a bundle by hand, add an entry to `bundles` with at least `name`,
+# `repository` and `description`, then run:
+#
+#     composer fetch-bundles
+#
+# That run fills in the rest. It refreshes description, version, updated,
+# stars, archived and abandoned on every run; `name` and any other keys you add
+# are left alone.
+#
+# Both lists are kept in alphabetical order here. The site renders `bundles`
+# most recently updated first, and skips anything marked abandoned; see
+# source/_views/includes/bundles.html.
+
+
+YAML;
+
+exit(main($argv));
+
+function main(array $argv): int
+{
+    $dryRun = in_array('--dry-run', $argv, true);
+
+    $config = loadConfig();
+
+    $ignored = array_map('normaliseRepositoryUrl', $config['ignored'] ?? []);
+
+    $existing = [];
+    foreach (['bundles', 'discovered'] as $list) {
+        foreach ($config[$list] ?? [] as $entry) {
+            if (isset($entry['repository'])) {
+                $existing[normaliseRepositoryUrl($entry['repository'])] = $list;
+            }
+        }
+    }
+
+    stderr('Searching GitHub...');
+
+    $repositories = [];
+    foreach (SEARCH_QUERIES as $query) {
+        foreach (searchRepositories($query) as $repository) {
+            $repositories[strtolower($repository['full_name'])] = $repository;
+        }
+    }
+
+    stderr(sprintf('  %d repositories returned.', count($repositories)));
+
+    $bundles = indexByRepository($config['bundles'] ?? []);
+    $discovered = indexByRepository($config['discovered'] ?? []);
+    $added = [];
+
+    foreach ($repositories as $repository) {
+        $url = normaliseRepositoryUrl($repository['html_url']);
+
+        if (in_array($url, $ignored, true)) {
+            continue;
+        }
+
+        if ($repository['fork']) {
+            continue;
+        }
+
+        if (!isDiscoverable($repository)) {
+            continue;
+        }
+
+        if (!isset($existing[$url])) {
+            $discovered[$url] = ['name' => humanise($repository['name']), 'repository' => $repository['html_url']];
+            $added[] = $repository['full_name'];
+        }
+    }
+
+    // Refresh both lists, including entries that were added by hand and so were
+    // never returned by a search.
+    foreach ([&$bundles, &$discovered] as &$list) {
+        foreach ($list as $url => $entry) {
+            stderr(sprintf('  %s', $entry['repository']));
+
+            $list[$url] = refresh($entry, $repositories[strtolower(repositorySlug($entry['repository']))] ?? null);
+        }
+    }
+    unset($list);
+
+    $config['bundles'] = sortByName($bundles);
+    $config['discovered'] = sortByName($discovered);
+    $config['ignored'] = array_values($config['ignored'] ?? []);
+
+    $yaml = FILE_HEADER.Yaml::dump($config, 4, 4, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+
+    if ($dryRun) {
+        echo $yaml;
+    } else {
+        file_put_contents(CONFIG_FILE, $yaml);
+    }
+
+    stderr('');
+    stderr(sprintf('%d listed, %d awaiting review.', count($config['bundles']), count($config['discovered'])));
+
+    if ($added) {
+        stderr('');
+        stderr(sprintf('Newly discovered (review before moving into `bundles`):%s  - %s', PHP_EOL, implode(PHP_EOL.'  - ', $added)));
+    }
+
+    return 0;
+}
+
+function loadConfig(): array
+{
+    if (!file_exists(CONFIG_FILE)) {
+        return ['bundles' => [], 'discovered' => [], 'ignored' => []];
+    }
+
+    return Yaml::parseFile(CONFIG_FILE) ?? [];
+}
+
+/**
+ * Bring one entry up to date. $repository is the GitHub search result, if the
+ * repository was returned by one of the searches.
+ */
+function refresh(array $entry, ?array $repository): array
+{
+    if (null === $repository) {
+        $repository = github('repos/'.repositorySlug($entry['repository']));
+    }
+
+    if (null === $repository) {
+        stderr('    ! repository not found on GitHub, leaving as-is');
+
+        return $entry;
+    }
+
+    $package = $entry['package'] ?? packageName($repository['full_name']);
+    $packagist = null !== $package ? packagist($package) : null;
+
+    $fresh = [
+        'description' => trim((string) ($repository['description'] ?? '')) ?: null,
+        'version' => null !== $packagist ? latestStableVersion(array_keys($packagist['versions'] ?? [])) : null,
+        'updated' => substr((string) $repository['pushed_at'], 0, 10),
+        'stars' => (int) $repository['stargazers_count'],
+        'archived' => (bool) $repository['archived'],
+        'abandoned' => null !== $packagist && ($packagist['abandoned'] ?? null) !== null,
+    ];
+
+    foreach (MANAGED_FIELDS as $field) {
+        // Description is seeded once, then left to the maintainer.
+        if ('description' === $field && isset($entry['description'])) {
+            continue;
+        }
+
+        $entry[$field] = $fresh[$field];
+    }
+
+    $entry['package'] = $package;
+    $entry['repository'] = $repository['html_url'];
+
+    return orderKeys($entry);
+}
+
+function isDiscoverable(array $repository): bool
+{
+    if (in_array(TOPIC, $repository['topics'] ?? [], true)) {
+        return true;
+    }
+
+    foreach (NAME_PATTERNS as $pattern) {
+        if (!preg_match($pattern, $repository['name'])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * @return array<int, array>
+ */
+function searchRepositories(string $query): array
+{
+    $repositories = [];
+
+    for ($page = 1; $page <= 10; ++$page) {
+        $response = github('search/repositories?'.http_build_query([
+            'q' => $query,
+            'per_page' => 100,
+            'page' => $page,
+        ]));
+
+        if (null === $response || empty($response['items'])) {
+            break;
+        }
+
+        $repositories = array_merge($repositories, $response['items']);
+
+        if (count($repositories) >= (int) $response['total_count']) {
+            break;
+        }
+    }
+
+    return $repositories;
+}
+
+/**
+ * Read the Composer package name out of a repository's composer.json.
+ */
+function packageName(string $slug): ?string
+{
+    $response = github('repos/'.$slug.'/contents/composer.json');
+
+    if (null === $response || !isset($response['content'])) {
+        return null;
+    }
+
+    $composer = json_decode((string) base64_decode($response['content'], true), true);
+
+    return $composer['name'] ?? null;
+}
+
+function packagist(string $package): ?array
+{
+    $response = get('https://packagist.org/packages/'.$package.'.json');
+
+    return $response['package'] ?? null;
+}
+
+function latestStableVersion(array $versions): ?string
+{
+    $stable = array_values(array_filter($versions, static function (string $version): bool {
+        return (bool) preg_match('/^v?\d+(\.\d+)*$/', $version);
+    }));
+
+    if (!$stable) {
+        return null;
+    }
+
+    usort($stable, 'version_compare');
+
+    return (string) end($stable);
+}
+
+function github(string $path): ?array
+{
+    $headers = ['Accept: application/vnd.github.mercy-preview+json'];
+
+    if ($token = getenv('GITHUB_TOKEN')) {
+        $headers[] = 'Authorization: token '.$token;
+    }
+
+    return get('https://api.github.com/'.$path, $headers);
+}
+
+function get(string $url, array $headers = []): ?array
+{
+    static $handle;
+
+    $handle = $handle ?: curl_init();
+
+    curl_setopt_array($handle, [
+        CURLOPT_URL => $url,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_TIMEOUT => 30,
+        CURLOPT_USERAGENT => USER_AGENT,
+        CURLOPT_HTTPHEADER => $headers,
+    ]);
+
+    $body = curl_exec($handle);
+    $status = (int) curl_getinfo($handle, CURLINFO_HTTP_CODE);
+
+    if (false === $body) {
+        stderr(sprintf('    ! %s: %s', $url, curl_error($handle)));
+
+        return null;
+    }
+
+    if (403 === $status || 429 === $status) {
+        stderr('    ! rate limited, sleeping for 60s');
+        sleep(60);
+
+        return get($url, $headers);
+    }
+
+    if (200 !== $status) {
+        return null;
+    }
+
+    return json_decode((string) $body, true);
+}
+
+/**
+ * @param array<int, array> $entries
+ *
+ * @return array<string, array>
+ */
+function indexByRepository(array $entries): array
+{
+    $indexed = [];
+
+    foreach ($entries as $entry) {
+        if (isset($entry['repository'])) {
+            $indexed[normaliseRepositoryUrl($entry['repository'])] = $entry;
+        }
+    }
+
+    return $indexed;
+}
+
+/**
+ * The file is kept in alphabetical order so that it stays easy to scan and so
+ * that a refresh produces a minimal diff. Display order is a separate concern,
+ * handled in source/_views/includes/bundles.html.
+ */
+function sortByName(array $entries): array
+{
+    $entries = array_values($entries);
+
+    usort($entries, static function (array $a, array $b): int {
+        return strcasecmp((string) ($a['name'] ?? ''), (string) ($b['name'] ?? ''));
+    });
+
+    return $entries;
+}
+
+function orderKeys(array $entry): array
+{
+    $order = ['name', 'package', 'repository', 'description', 'version', 'updated', 'stars', 'archived', 'abandoned'];
+
+    $ordered = [];
+    foreach ($order as $key) {
+        if (array_key_exists($key, $entry)) {
+            $ordered[$key] = $entry[$key];
+        }
+    }
+
+    return $ordered + $entry;
+}
+
+function normaliseRepositoryUrl(string $url): string
+{
+    return rtrim(strtolower($url), '/');
+}
+
+function repositorySlug(string $url): string
+{
+    return trim((string) parse_url($url, PHP_URL_PATH), '/');
+}
+
+/**
+ * "sculpin-twig-markdown-bundle" => "Twig Markdown Bundle"
+ * "SculpinRelatedContentBundle" => "Related Content Bundle"
+ */
+function humanise(string $name): string
+{
+    if (!preg_match('/[-_]/', $name)) {
+        $name = (string) preg_replace('/(?<!^)([A-Z])/', ' $1', $name);
+    }
+
+    $words = preg_split('/[-_\s]+/', $name, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+    $words = array_values(array_filter($words, static function (string $word): bool {
+        return 0 !== strcasecmp($word, 'sculpin');
+    }));
+
+    return ucwords(implode(' ', $words));
+}
+
+function stderr(string $message): void
+{
+    fwrite(STDERR, $message.PHP_EOL);
+}

--- a/source/_views/includes/bundles.html
+++ b/source/_views/includes/bundles.html
@@ -1,0 +1,41 @@
+{#
+    Renders site.bundles, which comes from app/config/bundles.yml.
+
+    That file is kept in alphabetical order so that it stays easy to scan and
+    so that refreshing it produces a readable diff. What gets shown, and in
+    what order, is decided here instead.
+
+    Bundles marked abandoned on Packagist stay in the YAML, so that the fetch
+    script does not rediscover them, but are not rendered. The rest are listed
+    most recently updated first, so that maintained bundles come before ones
+    that were last touched a decade ago.
+#}
+<div class="bundles">
+    <ul class="list-inline">
+        {% for bundle in site.bundles|filter(bundle => not bundle.abandoned)|sort((a, b) => b.updated <=> a.updated) %}
+            <li class="bundle">
+                <a class="title" href="{{ bundle.repository }}">{{ bundle.name }}</a>
+
+                <a class="source" href="{{ bundle.repository }}"><svg class="icon-github" width="10" height="10" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>GitHub</title><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> src</a>
+
+                {% if bundle.description %}
+                    <p class="description">{{ bundle.description }}</p>
+                {% endif %}
+
+                <p class="meta">
+                    {% if bundle.version %}
+                        <span class="version">{{ bundle.version }}</span>
+                    {% endif %}
+
+                    {% if bundle.updated %}
+                        <span class="updated">Updated {{ bundle.updated|date('M Y') }}</span>
+                    {% endif %}
+
+                    {% if bundle.archived %}
+                        <span class="flag">Archived</span>
+                    {% endif %}
+                </p>
+            </li>
+        {% endfor %}
+    </ul>
+</div>

--- a/source/community.md
+++ b/source/community.md
@@ -42,3 +42,14 @@ powered site you'd like to showcase here? Send a Pull Request to the
 GitHub, or reach out to <strong><a href="https://phpc.social/@sculpin">@sculpin@phpc.social</a></strong> on Mastodon!
 
 {% include 'includes/powered-by.html' %}
+
+<hr>
+
+## Bundles
+
+Bundles extend Sculpin with extra functionality. Have one you'd like listed
+here? Add the <code>sculpin-bundle</code> topic to your repository on GitHub, or
+send a Pull Request to the <a href="https://github.com/sculpin/sculpin.io">sculpin.io</a>
+repository.
+
+{% include 'includes/bundles.html' %}

--- a/source/css/style.css
+++ b/source/css/style.css
@@ -269,6 +269,52 @@ footer.site .copyright {
 	color: #DFE7EA;
 }
 
+.bundles ul.list-inline {
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-gap: 2vw;
+}
+
+.bundles ul li a {
+	text-decoration: none;
+}
+
+.bundles li.bundle {
+	padding: .5em;
+	text-align: left;
+}
+
+.bundles .bundle .title {
+	font-size: 1.2em;
+}
+
+.bundles .bundle .source {
+	color: #C0CFD5;
+	font-size: .75em;
+}
+.bundles .bundle .source:hover {
+	color: #DFE7EA;
+}
+
+.bundles .bundle .description,
+.bundles .bundle .meta {
+	font-size: .8em;
+	margin: .5em 0 0;
+}
+
+.bundles .bundle .meta {
+	color: #C0CFD5;
+}
+
+.bundles .bundle .meta span + span:before {
+	content: "\00b7  ";
+}
+
+.bundles .bundle .meta .flag {
+	color: #C1543F;
+	text-transform: uppercase;
+}
+
 
 section.content {
 	color: #547989;
@@ -610,6 +656,10 @@ only screen and (                min-resolution: 2dppx)  and (min-width: 600px) 
 @media only screen and (min-width: 768px) {
 	.powered-by .powered-by-site .source {
 		font-size: .5em;
+	}
+
+	.bundles ul.list-inline {
+		grid-template-columns: repeat(2, 1fr);
 	}
 }
 

--- a/source/index.html
+++ b/source/index.html
@@ -71,5 +71,13 @@ nav_name: home
   </p>
   {% include 'includes/powered-by.html' %}
 
+  <hr>
+
+  <h1>Bundles</h1>
+  <p>
+    Bundles extend Sculpin with extra functionality. Have one you'd like listed here? Add the <code>sculpin-bundle</code> topic to your repository on GitHub, or send a Pull Request to the <a href="https://github.com/sculpin/sculpin.io">sculpin.io</a> repository.
+  </p>
+  {% include 'includes/bundles.html' %}
+
 </div>
 


### PR DESCRIPTION
Adds a **Bundles** section to the home page and the community page, listing Sculpin bundles with their latest version, last update and a link to the repository. Rendered from a new `app/config/bundles.yml`, kept up to date by a script.

### Discovery

`scripts/fetch-bundles.php` finds bundles on GitHub and refreshes their metadata:

```
GITHUB_TOKEN=... composer fetch-bundles
```

A repository is picked up if it has the `sculpin-bundle` topic, or if its name contains both "sculpin" and "bundle". The Composer package name is read from each repository, then the version and abandoned status come from Packagist.

The name search is there because the topic is barely used — it currently matches **one** repository, where the name heuristic finds **36**. Neither the Composer `type` nor a `sculpin/sculpin` requirement works as a signal, since most existing bundles set neither.

### Nothing is published automatically

A GitHub topic is self-assigned, so auto-listing would let any repository appear on the project's own site. Instead the script writes new finds to a `discovered` list that isn't rendered; a maintainer moves the worthwhile ones into `bundles`. Anything that should never be listed goes in `ignored` so it isn't rediscovered.

This PR seeds `bundles` with the 5 extensions already documented under Community Extensions, and leaves 31 in `discovered` for review.

### Display

Ordering and filtering live in `source/_views/includes/bundles.html`, not in the YAML — the file stays alphabetical so refreshes produce a readable diff. Bundles marked abandoned on Packagist are skipped; the rest are listed most recently updated first. That matters because many bundles out there were last touched around 2015 and target Sculpin 1 or 2.

The last-updated date and an "Archived" flag are shown rather than used to filter, so readers can judge for themselves how current something is.

### Notes for reviewers

- `docs/` is regenerated. 23 of the 26 changed files differ **only** by picking up the `generator` metatag from b433764, which hadn't been regenerated into `docs/` yet. The real changes are `index.html`, `community/index.html` and `css/style.css`.
- The script is idempotent — two consecutive runs produce a byte-identical `bundles.yml`.

## Screenshot

<img width="1920" height="954" alt="Screenshot 2026-07-27 at 15-51-47 Sculpin — PHP Static Site Generator" src="https://github.com/user-attachments/assets/43d29aaf-c58f-4b31-935e-c3dbf8fddbe6" />
